### PR TITLE
fix(schema): enforce `order` and `limit` requirements

### DIFF
--- a/server/src/read.js
+++ b/server/src/read.js
@@ -27,8 +27,6 @@ module.exports.make_read_reql = function (request) {
   }
 
   if (order) {
-    // TODO: get this working in the schema
-    if (selection) { check(selection.type === 'between', `"order" is not allowed`); }
     if (order === 'descending') {
       reql = reql.orderBy({ index: r.desc(index) });
     } else {
@@ -37,8 +35,6 @@ module.exports.make_read_reql = function (request) {
   }
 
   if (limit) {
-    // TODO: get this working in the schema
-    if (selection) { check(selection.type !== 'find_one', `"limit" is not allowed`); }
     reql = reql.limit(limit);
   }
 

--- a/server/src/schema/protocol.js
+++ b/server/src/schema/protocol.js
@@ -4,23 +4,28 @@ const read = Joi.object({
   collection: Joi.string().token().required(),
   field_name: Joi.string().required(),
 
-  // TODO: 'order' should be valid when selection is unspecified, or selection.type is 'between'
-  order: Joi.string().valid('ascending', 'descending').optional(),
+  order: Joi.string().valid('ascending', 'descending')
+    .when('selection.type', {
+      is: Joi.any().valid('between').optional(),
+      otherwise: Joi.forbidden()
+    }),
 
-  // TODO: 'limit' should be valid when selection is unspecified, or selection.type is 'between' or 'find'
-  limit: Joi.number().positive().optional(),
+  limit: Joi.number().positive()
+    .when('selection.type', {
+      is: 'find_one',
+      then: Joi.forbidden()
+    }),
 
   selection: Joi.object({
-    type: Joi.string().valid([
-      'find',
-      'find_one',
-      'between'
-    ]),
-    args: Joi.alternatives()
-      .when('selection.type', { is: 'find', then: Joi.array().length(1) })
-      .when('selection.type', { is: 'between', then: Joi.array().length(2),
-                                otherwise: Joi.array() })
-  }).optional(),
+      type: Joi.string().valid([
+        'find',
+        'find_one',
+        'between'
+      ]),
+      args: Joi.array()
+        .when('selection.type', { is: 'find_one', then: Joi.array().single() })
+        .when('selection.type', { is: 'between', then: Joi.array().length(2) })
+    }).optional(),
 
     // .options({
     //   language: {

--- a/server/test/schema.js
+++ b/server/test/schema.js
@@ -5,7 +5,7 @@ const protocol = require('../src/schema/protocol');
 
 describe('Schema', () => {
 
-  it('request', (done) => {
+  it('protocol - request', (done) => {
     const request = {
       request_id: 1,
       type: 'query',
@@ -20,7 +20,46 @@ describe('Schema', () => {
     done();
   });
 
-  it('query - options', (done) => {
+  // TODO: all these tests assume failures but don't validate why
+
+  it('protocol - read - find', (done) => {
+    const options = {
+      collection: 'fusion',
+      field_name: 'id',
+      selection: {
+        type: 'find',
+        args: [ 1, 2, 3 ]
+      },
+      limit: 1,
+    };
+
+    var { error } = protocol.read.validate(options);
+
+    assert.ifError(error);
+
+    done();
+  });
+
+  it('protocol - read - between', (done) => {
+    const options = {
+      collection: 'fusion',
+      field_name: 'id',
+      selection: {
+        type: 'between',
+        args: [ 1, 2 ]
+      },
+      limit: 1,
+      order: 'descending',
+    };
+
+    var { error } = protocol.read.validate(options);
+
+    assert.ifError(error);
+
+    done();
+  });
+
+  it('protocol - read - find_one', (done) => {
     const options = {
       collection: 'fusion',
       field_name: 'id',
@@ -28,16 +67,12 @@ describe('Schema', () => {
         type: 'find_one',
         args: [ 1 ]
       },
-      // limit: 1,
-      // order: 'ascending'
+      limit: 1
     };
 
-    var { error, value } = protocol.read.validate(options);
+    var { error } = protocol.read.validate(options);
 
-    assert.ifError(error);
-    assert(value);
-    assert.equal(value.field_name, 'id');
-    assert.deepEqual(value.selection.args, [1]);
+    assert(error);
 
     done();
   });


### PR DESCRIPTION
@Tryneus schema is a bit cleaner than that first pass I did and fixes the issue you were running into with c324b9f. I think you also accidentally swapped `find <-> find_one` in the `selection.args` validator so I changed that back too.
