### PR TITLE
Fix for serializing query Date objects

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -142,7 +142,7 @@ function Fusion(host, { secure: secure = true } = {}) {
 
   function createSubscription(queryOptions, userOptions) {
     return createRequest((reqId, events) => {
-      let req = { type: 'subscribe', options: queryOptions, request_id: reqId }
+      let req = { type: 'subscribe', options: serialize(queryOptions), request_id: reqId }
       handshaken.then(() => socket.send(req))
       return Subscription({
         onResponse: events.onResponse,
@@ -156,12 +156,11 @@ function Fusion(host, { secure: secure = true } = {}) {
   }
 
   function writeOp(opType, collectionName, documents) {
-    let serializedDocs = serialize(documents)
-    return send(opType, { data: serializedDocs, collection: collectionName })
+    return send(opType, { data: serialize(documents), collection: collectionName })
   }
 
   function query(data) {
-    return send('query', data)
+    return send('query', serialize(data))
   }
 
   function endSubscription(requestId) {

--- a/client/test/api.js
+++ b/client/test/api.js
@@ -53,6 +53,7 @@ var Fusion = require("Fusion");
       describe("Testing `upsert`", upsertSuite(getData));
       describe("Testing `update`", updateSuite(getData));
       describe("Testing `replace`", replaceSuite(getData));
+      describe("Testing `times`", timesSuite(getData));
 
     }); // Storage API
 

--- a/client/test/fusionObject.js
+++ b/client/test/fusionObject.js
@@ -13,7 +13,7 @@ fusionObjectSuite = () => {
         // the Fusion object as its argument.
         assert.equal(fusion, _fusion);
 
-        // The dispose method fires the `disconnected` event (iff the client was
+        // The dispose method fires the `disconnected` event (if the client was
         // connected), then closes all connections and cleans up all resources
         // associated with the Fusion object.
         _fusion.dispose();

--- a/client/test/test.html
+++ b/client/test/test.html
@@ -29,6 +29,7 @@
   <script src="upsert.js"></script>
   <script src="update.js"></script>
   <script src="replace.js"></script>
+  <script src="times.js"></script>
 
   <!-- Test the removal commands -->
   <script src="remove.js"></script>

--- a/client/test/times.js
+++ b/client/test/times.js
@@ -1,0 +1,63 @@
+timesSuite = (getData) => {
+  return () => {
+
+  var data;
+
+  before(() => {
+    data = getData();
+  });
+
+  var range = (count) => Array.from(Array(count).keys());
+
+  beforeEach((done) => {
+    var rows = range(16).map((i) => ({ id: i, value: i % 4, time: new Date(Math.floor(i / 4)) }));
+    data.store(rows).then((res) => {
+      assert.isArray(res);
+      assert.lengthOf(res, 16);
+      done();
+    });
+  });
+
+  it("#.find(time: X)", (done) => {
+    data.find({ time: new Date(0) }).value().then((res) => {
+      assert.deepEqual({ id: 0, time: new Date(0), value: 0 }, res);
+      done();
+    }).catch(done);
+  });
+
+  it("#.find(value: X, time: Y)", (done) => {
+    data.find({ value: 1, time: new Date(3) }).value().then((res) => {
+      assert.deepEqual({ id: 13, value: 1, time: new Date(3) }, res);
+      done();
+    }).catch(done);
+  });
+
+  it("#.findAll(time: X)", (done) => {
+    data.findAll({ time: new Date(2) }).value().then((res) => {
+      assert.deepEqual(range(4).map((i) => ({ id: i + 8, value: i, time: new Date(2) })), res);
+      done();
+    }).catch(done);
+  });
+
+  it("#.findAll(value: X, time: Y)", (done) => {
+    data.findAll({ value: 2, time: new Date(3) }).value().then((res) => {
+      assert.deepEqual([{ id: 14, value: 2, time: new Date(3) }], res);
+      done();
+    }).catch(done);
+  });
+
+  it("#.findAll(value: X).above(time: Y)", (done) => {
+    data.findAll({ value: 3 }).above({ time: new Date(1) }).value().then((res) => {
+      assert.deepEqual(range(3).map((i) => ({ id: 3 + (i + 1) * 4, value: 3, time: new Date(i + 1) })), res);
+      done();
+    }).catch(done);
+  });
+
+  it("#.findAll(value: X).above(time: Y).below(time: Z)", (done) => {
+    data.findAll({ value: 2 }).above({ time: new Date(1) }).below({ time: new Date(3) }).value().then((res) => {
+      assert.deepEqual([{ id: 6, value: 2, time: new Date(1) }, { id: 10, value: 2, time: new Date(2) }], res);
+      done();
+    }).catch(done);
+  });
+  } // Testing `find`
+}


### PR DESCRIPTION
Added client tests for using times in queries, and fixed a place where query data was not being serialized correctly.
