### PR TITLE
Enabling CLIfication of project fusion server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-server",
   "version": "0.0.1",
-  "description": "Server for RethinkDB fusion",
+  "description": "Server for RethinkDB Project Fusion",
   "main": "main.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha --compilers js:babel-core/register test/test.js test/schema.js"
@@ -12,6 +12,9 @@
   },
   "author": "RethinkDB",
   "license": "MIT",
+  "bin": {
+    "fusion": "./src/main.js"
+  },
   "bugs": {
     "url": "https://github.com/rethinkdb/fusion/issues"
   },

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node --harmony-destructuring
 'use strict';
 
 const fusion = require('./server');


### PR DESCRIPTION
This enables `npm install -g` while in the fusion repo directory and then you will have access to `fusion` on your $PATH. 

Later when we are ready for `npm publish`, it will be just one step away. 
