### PR TITLE
Add a test script for launching the current version of the server and client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "fusion",
+  "name": "fusion-client",
   "version": "0.0.1",
   "description": "RethinkDB Fusion is an open-source developer platform for building realtime, scalable web apps. It is built on top of RethinkDB, and allows app developers to get started with building modern, engaging apps without writing any backend code.",
-  "main": "index.js",
+  "main": "dist/fusion.js",
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "geval": "^2.1.1",
@@ -23,7 +23,8 @@
     "watchify": "^3.6.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "./build.js build"
   },
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "argparse": "^1.0.3",
     "joi": "^7.0.0",
+    "fusion-client": "file:../client",
     "rethinkdb": "^2.1.1",
     "winston": "^2.1.0",
     "ws": "^0.8.0"

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -67,15 +67,15 @@ class Request {
     const metadata = this.client.parent._reql_conn.get_metadata();
     if (metadata === undefined) {
       this.client.send_response(this, { error: `Connection to the database is down.` });
+    } else {
+      metadata.handle_error(err, (inner_err) => {
+        if (inner_err) {
+          this.client.send_response(this, { error: inner_err.message });
+        } else {
+          setTimeout(() => this._run_reql(), 0);
+        }
+      });
     }
-
-    metadata.handle_error(err, (inner_err) => {
-      if (inner_err) {
-        this.client.send_response(this, { error: inner_err.message });
-      } else {
-        setTimeout(() => this._run_reql(), 0);
-      }
-    });
   }
 
   _handle_response(res) {

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -108,12 +108,23 @@ options.auto_create_index = Boolean(parsed.auto_create_index);
 // Wait for the http servers to be ready before launching the Fusion server
 let num_ready = 0;
 http_servers.forEach((serv) => {
+  serv.on('request', (req, res) => {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('File not found.');
+  });
+
+  serv.on('upgrade', (req, res) => {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Upgrade not defined at this endpoint.');
+  });
+
   serv.on('listening', () => {
     fusion.logger.info(`Listening on ${serv.address().address}:${serv.address().port}.`);
     if (++num_ready === http_servers.size) {
       new fusion.Server(http_servers, options);
     }
   });
+
   serv.on('error', (err) => {
     fusion.logger.error(`HTTP${parsed.unsecure ? '' : 'S'} server: ${err}`);
     process.exit(1);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -7,6 +7,8 @@ const logger = require('./logger');
 const fusion_protocol = require('./schema/fusion_protocol');
 const server_options = require('./schema/server_options');
 
+const fusion_client_path = require.resolve('fusion-client');
+
 const endpoints = {
   insert: require('./endpoint/insert'),
   query: require('./endpoint/query'),
@@ -86,11 +88,12 @@ class Server {
       const extant_listeners = server.listeners('request').slice(0);
       server.removeAllListeners('request');
       server.on('request', (req, res) => {
+        // TODO: might be nice to indicate that `opts.path` accepts UPGRADE requests?
         const req_path = url.parse(req.url).pathname;
         if (req_path.indexOf(opts.path + '/fusion.js') === 0) {
-          serve_file(path.resolve('../client/dist/fusion.js'), res);
+          serve_file(fusion_client_path, res);
         } else if (req_path.indexOf(opts.path + '/fusion.js.map') === 0) {
-          serve_file(path.resolve('../client/dist/fusion.js.map'), res);
+          serve_file(fusion_client_path + '.map', res);
         } else {
           extant_listeners.forEach((l) => l.call(server, req, res));
         }

--- a/test/serve.js
+++ b/test/serve.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node --harmony-destructuring
+'use strict'
+
+const server_test_utils = require('../server/test/utils');
+const fusion = require('../server');
+
+const assert = require('assert');
+const child_process = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const url = require('url');
+
+let client_ready = false;
+
+const serve_file = (file_path, res) => {
+  fs.access(file_path, fs.R_OK | fs.F_OK, (exists) => {
+    if (exists) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end(`File "${file_path}" not found\n`);
+    } else {
+      fs.readFile(file_path, 'binary', (err, file) => {
+        if (err) {
+          res.writeHead(500, { 'Content-Type': 'text/plain' });
+          res.end(`${err}\n`);
+        } else {
+          if (file_path.endsWith('.js')) {
+            res.writeHead(200, { 'Content-Type': 'application/javascript' });
+          } else if (file_path.endsWith('.html')) {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+          } else {
+              res.writeHead(200);
+          }
+          res.end(file, 'binary');
+        }
+      });
+    }
+  });
+};
+
+// TODO: add options for keeping the rethinkdb data dir or changing the logging level or port
+
+// Run the client build
+const build_proc = child_process.fork('../client/build.js', [ 'build' ], { cwd: '../client/' });
+build_proc.on('exit', (res) => {
+  assert.strictEqual(res, 0);
+  client_ready = true;
+});
+
+// Launch HTTP server with fusion that will serve the test files
+const http_server = new http.Server((req, res) => {
+  const req_path = url.parse(req.url).pathname;
+  serve_file(path.resolve('../client' + req_path), res);
+});
+
+
+// Launch rethinkdb - once we know the port we can attach fusion to the http server
+server_test_utils.start_rdb_server(() => {
+  assert.notStrictEqual(server_test_utils.rdb_port(), undefined);
+  console.log(`RethinkDB server listening on port ${server_test_utils.rdb_port()}.`);
+
+  fusion.logger.level = 'debug';
+  const fusion_server = new fusion.Server(http_server,
+                                          { auto_create_table: true,
+                                            auto_create_index: true,
+                                            rdb_port: server_test_utils.rdb_port() });
+
+  // Capture requests to `fusion.js` and `fusion.js.map` before the fusion server
+  const extant_listeners = http_server.listeners('request').slice(0);
+  http_server.removeAllListeners('request');
+  http_server.on('request', (req, res) => {
+    const req_path = url.parse(req.url).pathname;
+    if (req_path.indexOf('/fusion/fusion.js') === 0 ||
+        req_path.indexOf('/fusion/fusion.js.map') === 0) {
+      if (!client_ready) {
+        res.writeHead(503, { 'Content-Type': 'text/plain' });
+        res.end('Client build is ongoing, try again in a few seconds.');
+      } else {
+        serve_file(path.resolve(req_path.replace('/fusion', '../client/dist')), res);
+      }
+    } else {
+      extant_listeners.forEach((l) => l.call(http_server, req, res));
+    }
+  });
+
+  http_server.listen(8181, () => console.log('HTTP server listening on port 8181.'));
+});
+


### PR DESCRIPTION
The current workflow is super annoying and prone to mistakes, so I've added a test script at `./test/serve.js` that will:
- Build the client library
- Run a `rethinkdb` server
- Launch an HTTP server to serve the client library and client tests
- Attach a fusion server to the HTTP server

The script doesn't provide any options at the moment, but I think this is a start that will make people's lives way easier.  It should be possible to watch for changes in the client or server code to relaunch the server, but at the moment that is an exercise for the reader.  Also, the client build takes like 6 seconds on my machine, which seems kinda slow.
