### PR TITLE
Working docker-compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ client/build
 client/dist
 **/README.md
 *.log
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM node
-
-# RUN rm -rf /usr/local/lib/node_modules/npm \
-#  && git clone https://github.com/DIREKTSPEED-LTD/npm /usr/local/lib/node_modules/npm \
-#  && rm -rf /usr/local/lib/node_modules/npm/.git \
-#  && rm -f  /usr/bin/npm \
-#  && ln -s -f /usr/local/bin/npm /usr/bin/npm \
-#  && cd /usr/local/lib/node_modules/npm \
-#  && npm install
+FROM node:4
 
 RUN mkdir -p /usr/fusion
 COPY client /usr/fusion/client
@@ -17,4 +9,4 @@ RUN cd client; ./build.js
 RUN cd server; npm install -g
 
 EXPOSE 8181
-CMD ["fusion", "--dev"]
+CMD ["fusion", "--dev", "--bind", "all"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ rethinkdb:
   image: rethinkdb
   ports:
     - "28015:28015"
+    - "8080:8080"
+
 fusion:
   build: .
-  command: fusion --dev -c r:28015
-  extra_hosts:
-    - "r:fusion_rethinkdb_1"
+  command: fusion --dev -c rethinkdb:28015 --bind all
+  links:
+    - rethinkdb
   ports:
     - "8181:8181"


### PR DESCRIPTION
This PR is based on the original work from @dalanmiller.  It now includes a working docker-compose file that launches rethinkdb (exposing both client & webui ports) and links it to the fusion server.  To make the fusion server work within Docker, I had to pass the `--bind all` CLI flag to the Dockerfile CMD parameters.  This will allow a Fusion docker container to work without docker-compose.

I also had to add this flag to the docker-compose.yml to ensure that fusion would handle requests from outside the Docker network stack.

Note: I cleaned up the Dockerfile a bit, including removing uneeded code and now pointed to the 4.X series of NodeJS which is the current Long Term Support branch.

Long-term, I'd like to optimize the container build process.  Currently if you make a change to any of the fusion/fusion client code, the next docker build requires a complete npm install of both fusion and fusion client.
