### PR TITLE
Add option to make writes lazy

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -10,7 +10,10 @@ const { subscribeOrObservable } = require('./utility.js')
 
 module.exports = Fusion
 
-function Fusion(host, { secure: secure = true, path: path = 'fusion' } = {}) {
+function Fusion(host, { secure = true,
+                        path = 'fusion',
+                        lazyWrites = false,
+                       } = {}) {
   // Websocket Subject
   const socket = new FusionSocket(host, secure, path)
 
@@ -18,7 +21,7 @@ function Fusion(host, { secure: secure = true, path: path = 'fusion' } = {}) {
   // function so we can construct a collection simply by calling it
   // like fusion('my_collection')
   function fusion(name) {
-    return new Collection(sendRequest, name)
+    return new Collection(sendRequest, name, lazyWrites)
   }
 
   fusion.dispose = () => {

--- a/client/test/api.js
+++ b/client/test/api.js
@@ -23,7 +23,7 @@ describe('Core API tests', () => {
 
   // Set up the fusion connection before running these tests.
   before(done => {
-    fusion = Fusion('localhost:8181', { secure: false });
+    fusion = Fusion('localhost:8181', { secure: false, lazyWrites: true });
     fusion.connect(err => done(err))
     fusion.onConnected(() => {
       data = fusion('test_data')


### PR DESCRIPTION
This implements #103

To change whether writes are lazy or not:

``` js
let fusion = Fusion('localhost:8181', { lazyWrites: true })
```

Writes are eager by default
