### PR TITLE
Unbreak client build and fix serve urls in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ rethinkdb
 $ fusion --dev
 
 # Clients can connect directly from the browser on port 8181
-# The fusion client library is served from host:8181/fusion.js
+# The fusion client library is served from host:8181/fusion/fusion.js
 ```
 
 ### What does the code look like?

--- a/client/README.md
+++ b/client/README.md
@@ -16,7 +16,6 @@ Flag                | Description
 -w, --watch         | Watch directory for changes
 -U, --no-uglify     | Don't uglify output
 -S, --no-sourcemaps | Don't output sourcemaps
--g, --expose-global | Expose Fusion module as a global
 
 
 ## Running tests
@@ -35,14 +34,14 @@ First you need to ensure that you have included the `fusion.js` client library i
 ```html
 ...
 <head>
-<script src="//localhost:8181/fusion.js"></script>
+<script src="//localhost:8181/fusion/fusion.js"></script>
 </head>
 ...
 ```
 
 Then wherever you want to use Project Fusion you will need to `require` the Fusion client library and then connect to your running instance of Fusion Server.
 
-**Note:** if you started Fusion Server with `--insecure`, you'll need to [add the insecure flag](#fusion).
+**Note:** if you started Fusion Server with `--insecure`, you'll need to [disable the secure flag](#Fusion).
 
 ```javascript
 const Fusion = require("Fusion");
@@ -142,7 +141,7 @@ You can also get notifications when the client connects and disconnects from the
 
 Object which initializes the connection to a Fusion Server.
 
-If Fusion server has been started with `--unsecure` then you will need to connect unsecurely by passing `{secure: false}` as a second parameter.
+If Fusion server has been started with `--insecure` then you will need to connect unsecurely by passing `{secure: false}` as a second parameter.
 
 ###### Example
 
@@ -150,7 +149,7 @@ If Fusion server has been started with `--unsecure` then you will need to connec
 const Fusion = require("fusion")
 const fusion = Fusion("localhost:8181")
 
-const unsecure_fusion = Fusion('localhost:8181', { unsecure: true })
+const unsecure_fusion = Fusion('localhost:8181', { secure: false })
 ```
 
 #### Collection
@@ -403,8 +402,6 @@ chat.find(1).value().then((message) => {
 ##### watch({ rawChanges: false })
 
 Turns the query into a changefeed query, returning an observable that receives a live-updating view of the results every time they change.
-
-If you pass `rawChanges: true`, instead of
 
 ###### Example
 

--- a/client/build.js
+++ b/client/build.js
@@ -14,7 +14,6 @@ program
   .option('-w, --watch', 'Watch directory for changes')
   .option('-U, --no-uglify', `Don't uglify output`)
   .option('-S, --no-sourcemaps', `Don't output sourcemaps`)
-  .option('-g, --expose-global', `Expose Fusion module as a global`)
   .parse(process.argv)
 
 compile(program.watch)
@@ -34,7 +33,7 @@ function compile(watching) {
     packageCache: {},
     plugin: [ watchify ],
     debug: program.sourcemaps,
-    standalone: program.exposeGlobal ? 'Fusion' : '',
+    standalone: 'Fusion',
   }).require('./src/index.js', { expose: 'Fusion' })
     .transform('babelify', {
     // All source files need to be babelified first


### PR DESCRIPTION
UMD builds will expose a global when not already in a module environment (where `require` is defined).
Client is currently served from `/fusion/fusion.js`.
