### PR TITLE
test/serve.js: show notification in console when webpack starts building

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -23,7 +23,7 @@ npm run devtest     | Run tests and linting continually
 ## Running tests
 
 * `npm test` or open `dist/test.html` in your browser after getting setup and while you also have Horizon server with the `--dev` flag running on `localhost`.
-* You can spin up a dev server by cloning the horizon repo and running `node serve.js` in `test` directory in repo root. Then tests can be accessed from <http://localhost:8181/dist/test.html>. Source maps work properly when served via http, not from file system. You can test the production version via `NODE_ENV=production node serve.js`.
+* You can spin up a dev server by cloning the horizon repo and running `node serve.js` in `test` directory in repo root. Then tests can be accessed from <http://localhost:8181/test.html>. Source maps work properly when served via http, not from file system. You can test the production version via `NODE_ENV=production node serve.js`. You may want to use `test/setupDev.sh` to set the needed local npm links for development.
 
 ## Docs
 


### PR DESCRIPTION
Webpack uses stderr to show build progress, but serve.js takes only full lines from child process. Piping webpack's stderr data directly would mess console output a bit, as backspaces may happen at spurious moments. Here's a version which just pipes a couple of progress notifications, compile and emit. Note that there might be more emits than compiles (as evidenced in production build), so one cannot use this at the moment to see if compilation is going on.

Also fixed docs for test.html served from root, and added back the initial compilation waiting message, adapted for webpack. One could use webpack's built-in ProgressPlugin to customize these notifications if needed for cleaner logging.
