### PR TITLE
Docs: Horizon connection is created using a plain function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Here is currently what you'd write on the front-end for a simple todo list appli
 
 ```js
 // Connect to horizon
-const horizon = new Horizon();
+const horizon = Horizon();
 const todoCollection = horizon("todo-items");
 
 const todoApp = document.querySelector('#app')

--- a/client/README.md
+++ b/client/README.md
@@ -48,7 +48,7 @@ Then wherever you want to use Project Horizon you will need to `require` the Hor
 
 ```javascript
 const Horizon = require("@horizon/client"); // or use global `window.Horizon`
-const horizon = new Horizon();
+const horizon = Horizon();
 ```
 
 From here you can start to interact with RethinkDB collections through the Horizon collection. Having `--dev` mode enabled on the Horizon Server creates collections and indexes automatically so you can get your application setup with as little hassle as possible.

--- a/examples/react-chat-app/app.jsx
+++ b/examples/react-chat-app/app.jsx
@@ -9,7 +9,7 @@ var app = app || {};
   'use strict';
 
   //Setup Horizon connection
-  const horizon = new Horizon();
+  const horizon = Horizon();
 
   app.ChatApp = React.createClass({
 

--- a/examples/riotjs-chat-app/chat.tag
+++ b/examples/riotjs-chat-app/chat.tag
@@ -23,7 +23,7 @@
   </div>
 
   <script>
-    horizon = new window.Horizon();
+    horizon = window.Horizon();
     this.messages = [];
     this.db = horizon("riotjs_chat");
 

--- a/examples/vue-chat-app/app.js
+++ b/examples/vue-chat-app/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const horizon = new Horizon();
+const horizon = Horizon();
 const chat = horizon('chat')
 const app = new Vue({
 

--- a/examples/vue-todo-app/js/store.js
+++ b/examples/vue-todo-app/js/store.js
@@ -3,7 +3,7 @@
 
   'use strict';
 
-  const horizon = new Horizon();
+  const horizon = Horizon();
   const todos = horizon("vuejs_todos");
 
   exports.todoStorage = {


### PR DESCRIPTION
The client was a constructor in earlier versions, but I guess the intention is to just call it as a function.
