### PR TITLE
Server tests working by removing babel-register

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,6 +58,6 @@ test:
         parallel: true
 
     # Run server tests
-    - mkdir -p $CIRCLE_TEST_REPORTS/xunit; touch $CIRCLE_TEST_REPORTS/xunit/server-tests.xml; ./node_modules/.bin/mocha --compilers js:babel-core/register -R xunit test/test.js test/schema.js > $CIRCLE_TEST_REPORTS/xunit/server-tests.xml:
+    - mkdir -p $CIRCLE_TEST_REPORTS/xunit; touch $CIRCLE_TEST_REPORTS/xunit/server-tests.xml; ./node_modules/.bin/mocha --timeout 15000 -R xunit test/test.js test/schema.js > $CIRCLE_TEST_REPORTS/xunit/server-tests.xml:
         pwd: server
         parallel: true

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "Server for RethinkDB Horizon, an open-source developer platform for building realtime, scalable web apps.",
   "main": "src/horizon.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --compilers js:babel-core/register test/test.js test/schema.js"
+    "test": "./node_modules/.bin/mocha test/test.js test/schema.js --timeout 10000"
   },
   "repository": {
     "type": "git",

--- a/server/test/prereq_tests.js
+++ b/server/test/prereq_tests.js
@@ -15,7 +15,6 @@ const all_tests = (table) => {
   it('table create race on read',
      /** @this mocha */
      function(done) {
-       this.timeout(5000);
        const query_count = 5;
        const table_name = crypto.randomBytes(8).toString('hex');
 
@@ -40,7 +39,6 @@ const all_tests = (table) => {
   it('table create race on write',
      /** @this mocha */
      function(done) {
-       this.timeout(5000);
        const query_count = 5;
        const table_name = crypto.randomBytes(8).toString('hex');
 

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -14,7 +14,6 @@ const table = 'test';
 before('Start RethinkDB Server',
        /** @this mocha */
        function(done) {
-         this.timeout(5000);
          utils.test_db_server(done);
        });
 
@@ -31,7 +30,6 @@ describe('Horizon Server', () => {
   before('Start Horizon Server',
          /** @this mocha */
          function(done) {
-           this.timeout(5000);
            utils.start_horizon_server(done);
          });
 
@@ -40,7 +38,6 @@ describe('Horizon Server', () => {
   before(`Creating general-purpose table: '${table}'`,
          /** @this mocha */
          function(done) {
-           this.timeout(5000);
            utils.create_table(table, done);
          });
 


### PR DESCRIPTION
Hi, `cd server; npm test` work by not using `babel-register` (or `babel-core/register`) when running the tests. 

Previous usage was quite funky, as babel-register installs a require hook to compile all the files (excluding `node_modules`), including the src which are otherwise perfectly runnable by `test/serve.js`, among others. So using mocha's `--compilers` flag is very suspect here, more proper would be to use `--require babel-register` or similar, but even then there is something strange going on: perhaps there is some interaction with native node promises, babel core-js polyfilled promises and rethinkdb-driver's bluebird promises. Maybe mixing them up caused those problems? 

When one needs babel features server side, it is usually easier to just use babel directly. For example, I used these one-liners in `package.json` to set breakpoints in node-inspector, before realising that the tests run fine without babel:

```
"testdebug": "nodemon --watch src,test --exec 'npm run build -s && npm run testbuild -s -- --no-timeouts --debug-brk'",
"build": "babel test --out-dir libtest --source-maps true",
"testbuild": "mocha libtest/test.js libtest/schema.js --timeout 10000 --require 'source-map-support/register'"
```

It takes a while for node-inspector to load, but being able to reload the server and come back to the same breakpoint, without having to clean up extra logging afterwards, is nice.
