### PR TITLE
WIP: Engine.io transport

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.5.0",
+    "core-js": "^2.1.0",
+    "engine.io-client": "^1.6.8",
     "rx": "^4.0.7",
     "snake-case": "^1.1.1"
   },
@@ -24,7 +26,7 @@
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
     "babel-eslint": "^5.0.0",
-    "babel-loader": "^6.2.3",
+    "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.5.0",
     "babel-plugin-transform-function-bind": "^6.5.2",
     "babel-plugin-transform-runtime": "^6.5.2",
@@ -32,12 +34,11 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "chai": "^3.4.0",
     "copy-webpack-plugin": "^1.1.1",
-    "core-js": "^1.2.0",
     "eslint": "^2.2.0",
     "lodash": "^4.5.0",
     "minimist": "^1.2.0",
     "mocha": "2.3.4",
-    "nodemon": "^1.9.0",
+    "nodemon": "^1.9.1",
     "source-map-support": "^0.4.0",
     "webpack": "^1.12.13",
     "ws": "^1.0.1"

--- a/client/src/index-polyfill.js
+++ b/client/src/index-polyfill.js
@@ -4,7 +4,24 @@ if (typeof window !== 'undefined') {
   if (typeof window.Rx !== 'undefined') {
     // Insert helpful warning here
   } else {
+    // In polyfill version we expose Rx, as users generally want to use the
+    // same Rx as the library itself -- for example `Rx.Observable.empty()`
     window.Rx = require('rx')
+  }
+
+  if (typeof window.eio !== 'undefined') {
+    // Insert helpful warning here
+  } else {
+    if (window.document) { // eslint-disable-line no-lonely-if
+      // In polyfill version we also expose eio for now. This is mostly so that
+      // we remember that eio can be omitted from the build if the user wants
+      // to use only websockets.
+      window.eio = require('engine.io-client/engine.io.js')
+    } else {
+      // This becomes `window.eio = window.eio` due to externals in webpack config,
+      // so that it is not bundled to non-polyfilled version.
+      window.eio = require('engine.io-client')
+    }
   }
 }
 

--- a/client/src/shim.js
+++ b/client/src/shim.js
@@ -1,10 +1,185 @@
-/* global WebSocket */
+'use strict';
 
-// Check for websocket
-if (typeof WebSocket !== 'undefined') {
+// Some constants from `process.env` are included in the package for now.
+// See `DefinePlugin` in webpack config.
+/* global process */
+
+// Importing eio here is a bit subtle, due to the way browser packaging works.
+// Horizon is webpacked in browser mode, and thus also the dependencies
+// of eio, such as `engine.io-parser`, are required by their `browser` field
+// in `package.json`, instead of the `main` field. This would cause the horizon
+// client to be unrunnable in node tests without modification. So here we'll
+// simply require the pre-packaged browser bundle directly, or the main
+// lib, depending on which runtime environment we are in. The imports won't
+// inflate the size of the package because `engine.io-client` is listed as an
+// external in webpack config, thus omitting it from package.
+// A longer term solution could be to build the browser and node bundles
+// separately (and there is currently the `lib` dir which could be used
+// directly), and thus also test them separately.
+
+// In non-polyfilled version eio is imported from `window.eio`.
+
+const eio = (typeof window !== 'undefined' && window.document) ?
+  require('engine.io-client/engine.io.js') :
+  require('engine.io-client')
+
+class EioWebSocket {
+  constructor(hostString, protocol) {
+    // To keep it lean, there's no event emitter api here (e.g. `.on('message')`).
+    this.onerror = null
+    this.onopen = null
+    this.onmessage = null
+    this.onclose = null
+    this.readyState = 0
+
+    this._errorEvent = null
+    this._closeEvent = null
+
+    // May throw
+    const eioSocket = this.eioSocket = eio(hostString, {
+      // TODO proper path parsing from hostString
+      path: hostString.match(/.*(\/[^?]+)/)[1],
+      // Sends protocol via a query parameter for now.
+      query: { protocol: protocol },
+      upgrade: true,
+      forceJSONP: false,
+      jsonp: false,
+      // Let's disable binary transports for now
+      forceBase64: true,
+      enablesXDR: false,
+      timestampParam: 't',
+      timestampRequests: true,
+      transports: [ 'polling', 'websocket' ],
+      rememberUpgrade: false,
+      onlyBinaryUpgrades: false,
+      perMessageDeflate: false // default { threshold: 1024 },
+    });
+
+    eioSocket.on('handshake', data => {
+      data.upgrades = data.upgrades
+      data.pingInterval = data.pingInterval
+      // Decreases pingTimeout to detect broken sockets sooner.
+      // NOTE: due to engine.io internals, ping timeout can still be longer
+      // in practice (there are logic mistakes in heartbeat handling)
+      data.pingTimeout = 10000;
+      // You can delete unneeded query params after handshake to save bytes in
+      // polling, or keep them for routing and logging
+      delete eioSocket.transport.query.b64;
+      delete eioSocket.transport.query.EIO;
+      delete eioSocket.transport.query.protocol;
+    })
+
+    eioSocket.on('open', () => {
+      this.readyState = 1;
+      this.onopen && this.onopen()
+    })
+
+    eioSocket.on('message', str => {
+      if (this.onmessage && str.charAt(0) !== '_') {
+        this.onmessage({ data: str })
+      } else {
+        this._closeEvent = JSON.parse(str.substr(1))
+      }
+    })
+
+    eioSocket.on('close', reason => {
+      // common reasons: 'transport error', 'ping timeout', 'forced close'
+      this.readyState = 3
+      const isError = (this._errorEvent || (reason !== 'forced close'))
+      const finalEvent = {
+        code: isError ? 1006 : 1000,
+        wasClean: Boolean(isError),
+        reason: reason,
+      }
+      finalEvent.code =
+        (this._closeEvent && this._closeEvent.code) ||
+        finalEvent.code
+
+      finalEvent.reason =
+        (this._closeEvent && this._closeEvent.reason) ||
+        (this._errorEvent && this._errorEvent.message) ||
+        finalEvent.reason
+
+      // Defer so that HorizonSocket can remove its onclose handlers when self closing
+      setTimeout(() => {
+        this.onclose && this.onclose(finalEvent)
+      }, 0)
+    })
+
+    eioSocket.on('error', error => {
+      // We don't know what kind of an error we get, so try to get some info.
+      // Common errors: 'xhr poll error', 'server error', 'websocket error'
+      this._errorEvent = (error instanceof Error) ? error : new Error(error)
+      if (error && error.description) {
+        this._errorEvent.message =
+          `${this._errorEvent.message || ''}: ${error.description}`
+      }
+
+      // Note: Grab eioSocket.writeBuffer if you really need it.
+      this.onerror && this.onerror(this._errorEvent)
+
+      // TODO perhaps call `this.close(1006)` or `eioSocket.close()` here,
+      // or perhaps even `eioSocket.transport.close('reason')`, but for
+      // the moment it seems that `socket.close` gets called via other means.
+      // Revisit this when reconnection logic is implemented in higher layer.
+    })
+
+    // TODO What kind of guarantees there are for re-entrancy and idempotency
+    // in case of errors, double closes, etc.
+    // TODO Tests for transport breakage. For example, test that if `upgadeError`
+    // comes after 'upgrading' but before 'upgraded', the socket won't be broken
+    // for socket timeout (10 s) as in some previous versions of eio.
+    // If disconnect or error happens during an upgrade, a GET request could also
+    // stay hanging. It should not matter (will typically error after keepalive
+    // timeout of 2 mins), but it could reserve browser connection pool.
+    // Rudimentary tests can be implemented by listening for specific events,
+    // such as `upgrading` and then breaking the transport by
+    // `eioSocket.transport.ws.close()` or
+    // if (eioSocket.transport.pollXhr.xhr !== null)
+    //   eioSocket.transport.pollXhr.abort();
+    // etc.
+  }
+
+  // Callback argument is very non-standard, but included here as both ws and
+  // engine.io-client support it.
+  send(str, callback) {
+    this.eioSocket.send(str, callback)
+  }
+
+  close(code /* , reason*/) {
+    if (code && code !== 1000) {
+      throw new Error('socket.close(code, reason) is unimplemented')
+    }
+
+    if (this.readyState < 2) {
+      this.readyState = 2
+
+      // Client->Server close codes are not used yet.
+      // if (arguments.length) {
+      //   this.eioSocket.send('_' + JSON.stringify({code: code, reason: reason}))
+      // }
+      this.eioSocket.close()
+    }
+  }
+}
+
+// WebSocket readyStates
+EioWebSocket.CONNECTING = 0
+EioWebSocket.OPEN = 1
+EioWebSocket.CLOSING = 2
+EioWebSocket.CLOSED = 3
+
+// Use engine.io-client if not disabled in build
+if (
+  !process.env.NO_EIO ||
+  String(process.env.NO_EIO) === 'false' ||
+  String(process.env.NO_EIO) === '0'
+) {
+  module.exports.WebSocket = EioWebSocket
+} else if (typeof WebSocket !== 'undefined') {
   module.exports.WebSocket = WebSocket
 } else {
   module.exports.WebSocket = () => {
-    console.error(`Tried to use WebSocket but it isn't defined or polyfilled`)
+    console.error('Tried to use WebSocket but it isn\'t defined or polyfilled')
   }
 }

--- a/client/test/test.js
+++ b/client/test/test.js
@@ -17,6 +17,7 @@ if (BROWSER) {
   require('mocha/mocha.js')
   // Expose globals such as describe()
   window.mocha.setup('bdd')
+  window.mocha.timeout(10000)
 } else {
   // Emulate window globals in node for now
   global.window = global
@@ -48,7 +49,7 @@ window.assert = window.chai.assert
 
 window._ = require('lodash/lodash.js')
 
-window.Rx = require('rx/dist/rx.all.js')
+assert.isDefined(window.Rx, 'Rx is exposed to window from horizon.js bundle')
 window.Rx.config.longStackSupport = true
 
 // Wait until server is ready before proceeding to tests

--- a/client/webpack.test.config.js
+++ b/client/webpack.test.config.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
 const CopyWebpackPlugin = require('copy-webpack-plugin')
+const NoErrorsPlugin = require('webpack/lib/NoErrorsPlugin')
 
 const DEV_BUILD = (process.env.NODE_ENV !== 'production')
 const SOURCEMAPS = !process.env.NO_SOURCEMAPS
@@ -12,7 +13,9 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
-    pathinfo: DEV_BUILD, // Add module filenames as comments in the bundle
+    // Add module filenames as comments in the bundle
+    pathinfo: DEV_BUILD,
+    // Configure source map urls visible in stack traces and "sources" panel
     devtoolModuleFilenameTemplate: function(file) {
       if (file.resourcePath.indexOf('webpack') >= 0) {
         return 'webpack:///' + file.resourcePath
@@ -35,11 +38,11 @@ module.exports = {
   module: {
     noParse: [
       // Pre-built files don't need parsing
-      /mocha\/mocha\.js/,
-      /chai\/chai\.js/,
-      /lodash\/lodash\.js/,
-      /source-map-support/,
-      /rx\/dist\/rx\.all\.js/,
+      RegExp('mocha/mocha.js'),
+      RegExp('chai/chai.js'),
+      RegExp('lodash/lodash.js'),
+      RegExp('source-map-support'),
+      RegExp('rx/dist/rx.all.js'),
     ],
     loaders: [
       {
@@ -68,6 +71,7 @@ module.exports = {
     __filename: false,
   },
   plugins: [
+    new NoErrorsPlugin(),
     new CopyWebpackPlugin([
       { from: './test/test.html' },
       { from: './node_modules/mocha/mocha.css' },

--- a/server/package.json
+++ b/server/package.json
@@ -20,8 +20,8 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "joi": "^7.0.0",
     "cookie": "^0.2.3",
+    "engine.io": "^1.6.8",
     "@horizon/client": "^0.0.2-1",
     "joi": "^7.0.0",
     "jsonwebtoken": "^5.5.4",

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -3,10 +3,10 @@
 const check = require('./error').check;
 const logger = require('./logger');
 const schemas = require('./schema/horizon_protocol');
+const websocket = require('./websocket');
 
 const Joi = require('joi');
 const r = require('rethinkdb');
-const websocket = require('ws');
 
 class Request {
   constructor(client, raw_request) {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -7,6 +7,7 @@ const ReqlConnection = require('./reql_connection').ReqlConnection;
 const logger = require('./logger');
 const horizon_protocol = require('./schema/horizon_protocol');
 const options_schema = require('./schema/server_options').server;
+const websocket = require('./websocket');
 
 // TODO: dynamically serve different versions of the horizon
 // library. Minified, Rx included etc.
@@ -27,7 +28,6 @@ const assert = require('assert');
 const fs = require('fs');
 const Joi = require('joi');
 const url = require('url');
-const websocket = require('ws');
 const extend = require('util')._extend;
 
 const protocol_name = 'rethinkdb-horizon-v0';

--- a/server/src/websocket.js
+++ b/server/src/websocket.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const eio = require('engine.io');
+
+// Create a constructor that mimics ws.Server, but returns an EioServer instance.
+// The api is otherwise quite compatible (`connection`, `message`, `send`,
+// `close` etc), so it is ok that the socket instances are used elsewhere as-is.
+
+class EioServer {
+  constructor(opts) {
+    const eio_server = new eio.Server({
+      path: opts.path,
+      // eio_server will expect any data in pingInterval + pingTimeout or it
+      // will close the eio_socket with 'ping timeout'. Both parameters are
+      // transferred to the client, and it is client's responsibility to
+      // periodically ping the server. In client, pingTimeout means the time
+      // until server response, so these server-sent parameters are customized
+      // there for client use.
+      pingTimeout: 60000,
+      pingInterval: 25000,
+      upgradeTimeout: 10000,
+      maxHttpBufferSize: 10E7,
+      transports: [ 'polling', 'websocket' ],
+      // Disable `allowUpgrades` if you want to test just polling
+      allowUpgrades: true,
+      allowRequest: (req, fn) => {
+        const protocols = (req._query.protocol || '').split(/, */);
+        opts.handleProtocols(protocols, (result /* , protocol */) => {
+          if (!result) {
+            fn(401, false);
+            return;
+          }
+          opts.verifyClient(null, (success, code /* , reason */) => {
+            if (!success) {
+              fn(code, false);
+              return;
+            }
+            fn(null, true);
+          });
+        });
+      },
+      cookie: false, // or name for sticky load balancing
+      cookiePath: false,
+      // Websocket compression will tax the server quite a lot, enable when possible.
+      perMessageDeflate: false, // default { threshold: 1024 },
+      // httpCompression should be done via nginx or similar, enable when possible.
+      httpCompression: false, // default { threshold: 1024 },
+    });
+
+    // Call stack to eio_server request handling could be shortened later:
+    // eio_server.attach method is quite simple to unwrap.
+    eio_server.attach(opts.server, {
+      path: opts.path,
+      destroyUpgrade: true,
+      destroyUpgradeTimeout: 1000,
+    });
+
+    // Return eio_server which is compatible with ws.Server
+    return eio_server;
+  }
+}
+
+// Patch eio_socket.close() to tolerate WebSocket#close(code, reason) arguments
+const original_close = eio.Socket.prototype.close;
+eio.Socket.prototype.close = function close(discard_or_code, reason) {
+  let discard = (discard_or_code === true);
+  if (discard) {
+    // Only called internally by eio in eio_server.close()
+    original_close.call(this, true);
+    return;
+  }
+  let code = (typeof discard_or_code === 'number') ? discard_or_code : null;
+  if (code !== null && code !== 1000) {
+    // WebSocket/ws close code workaround, sends a special message
+    this.send('_' + JSON.stringify({ code: code, reason: reason }));
+    setImmediate(() => {
+      original_close.call(this);
+    });
+    return;
+  }
+  // Else ordinary eio_socket.close() call
+  original_close.call(this);
+};
+
+module.exports =
+  (process.env.NO_EIO === 'true' || process.env.NO_EIO === '1') ?
+  require('ws') :
+  {
+    // Emulate ws server api
+    Server: EioServer,
+    // WebSocket readyStates <> EioSocket readyStates
+    CONNECTING: 'opening',
+    OPEN: 'open',
+    CLOSING: 'closing',
+    CLOSED: 'closed',
+  };


### PR DESCRIPTION
Here's a version with engine.io transport (long polling + websockets) that we can play around with. All tests pass (client in node, client in browser, server in node). So this should work in older user agents and in more challenging network conditions. Note that there is no reconnection logic here -- it should be implemented on a higher level.

Changes made:
- Extended `client/src/shim.js` to simulate a websocket-like interface via engine.io. The most experimental part is simulating websocket close codes by special messages, that should be implemented more robustly if adopted.
- Changed server tests in `server/test/` to use WebSocket API instead of event emitter API. `ws` module supports both, but it is easier for the client side to not have to inherit event emitter just because server side uses it.
- Implemented `server/src/websocket.js` that mimics `ws` server interface and constructor, and attached it to the given server instance. This can be optimized later, the call stack may be pretty steep now. I also monkey-patched engine.io socket prototype to have some support for close codes. Luckily ws and engine.io use same kind of event emitter api in their socket abstractions, so the sockets seem to be integrating with the rest of the system as-is, and that's why the changes are so few.

Using the websocket api like this, one could imagine doing the same with server-sent events etc.

I haven't tried if secure sockets work yet.

You can disable the transport by running/compiling things with NO_EIO env variable set.
