### PR TITLE
Polyfill only the needed features

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,33 +13,33 @@
     "prepublish": "npm run build && npm run compile"
   },
   "dependencies": {
-    "babel-runtime": "^6.5.0",
-    "rx": "^4.0.7",
-    "snake-case": "^1.1.1"
+    "babel-runtime": "^6.6.1",
+    "core-js": "^2.1.0",
+    "rx": "^4.0.8",
+    "snake-case": "^1.1.2"
   },
   "engines": {
     "node": ">=4.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.5.1",
-    "babel-core": "^6.5.2",
+    "babel-cli": "^6.6.4",
+    "babel-core": "^6.6.4",
     "babel-eslint": "^5.0.0",
-    "babel-loader": "^6.2.3",
+    "babel-loader": "^6.2.4",
     "babel-plugin-transform-async-to-generator": "^6.5.0",
     "babel-plugin-transform-function-bind": "^6.5.2",
-    "babel-plugin-transform-runtime": "^6.5.2",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-plugin-transform-runtime": "^6.6.0",
+    "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-loose": "^7.0.0",
-    "chai": "^3.4.0",
+    "chai": "^3.5.0",
     "copy-webpack-plugin": "^1.1.1",
-    "core-js": "^1.2.0",
     "eslint": "^2.2.0",
-    "lodash": "^4.5.0",
+    "lodash": "^4.6.1",
     "minimist": "^1.2.0",
     "mocha": "2.3.4",
-    "nodemon": "^1.9.0",
+    "nodemon": "^1.9.1",
     "source-map-support": "^0.4.0",
-    "webpack": "^1.12.13",
+    "webpack": "^1.12.14",
     "ws": "^1.0.1"
   },
   "main": "lib/index.js",

--- a/client/src/index-polyfill.js
+++ b/client/src/index-polyfill.js
@@ -1,9 +1,16 @@
-require('core-js/shim')
+// Ensures these features are present or polyfilled
+// See http://kangax.github.io/compat-table/es6/
+require('core-js/fn/array/from');
+require('core-js/fn/array/find-index');
+require('core-js/fn/array/keys');
+require('core-js/fn/object/assign');
 
 if (typeof window !== 'undefined') {
   if (typeof window.Rx !== 'undefined') {
     // Insert helpful warning here
   } else {
+    // In polyfill version we expose Rx, as users generally want to use the
+    // same Rx as the library itself -- for example `Rx.Observable.empty()`
     window.Rx = require('rx')
   }
 }

--- a/client/test/test.js
+++ b/client/test/test.js
@@ -17,6 +17,7 @@ if (BROWSER) {
   require('mocha/mocha.js')
   // Expose globals such as describe()
   window.mocha.setup('bdd')
+  window.mocha.timeout(10000)
 } else {
   // Emulate window globals in node for now
   global.window = global

--- a/client/webpack.horizon.config.js
+++ b/client/webpack.horizon.config.js
@@ -68,7 +68,7 @@ module.exports = function(buildTarget) {
         loader: 'babel-loader',
         query: {
           cacheDirectory: true,
-          extends: './src/.babelrc',
+          extends: path.resolve(__dirname, 'src/.babelrc'),
         },
       },
     ],


### PR DESCRIPTION
First step in #141, polyfills only the needed features.

Removed `core-js/shim` / `babel-polyfill` and ran tests in Win7/IE10 via BrowserStack and added polyfills until there were no errors. (Ran also engine.io branch in IE9, tests pass). Perhaps you could run tests via CircleCI in BrowserStack or SauceLabs to detect these kind of regressions, so you could comfortably use new ES6 features.
There were only four polyfills needed: Array.from, Array#findIndex, Array#keys, Object.assign. This reduces the gzipped size of polyfilled version from 65 KB to 47 KB, most of which is still Rx.
Also moved core-js from devDependencies to dependencies proper, for importing lib/ in module packagers.
Also upgraded babel-runtime, babel-plugin-transform-runtime and core-js to "^2.1.0" so they use the same versions, allowing deduping by webpack optimizer.
Also increased timeout of in-browser tests to 10 s.

Also fixes recent babel change of .babelrc resolving, fixing build error (the project may need to start pinning the dependencies soon?).
