### PR TITLE
Fix for CLI shutdown and rethinkdb cleanup

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const horizon_server = require('@horizon/server');
+const interrupt = require('./utils/interrupt');
 
 const fs = require('fs');
 const http = require('http');
@@ -434,15 +435,17 @@ const runCommand = (opts, done) => {
 
   let http_servers, hz_instance;
 
-  const shutdown = () => {
+  interrupt.on_interrupt((done) => {
     if (hz_instance) {
       hz_instance.close();
     }
-    process.exit(0);
-  };
-
-  process.on('SIGTERM', shutdown);
-  process.on('SIGINT', shutdown);
+    if (http_servers) {
+      http_servers.forEach((serv) => {
+        serv.close();
+      });
+    }
+    done();
+  });
 
   return (
     opts.insecure ?

--- a/cli/src/utils/interrupt.js
+++ b/cli/src/utils/interrupt.js
@@ -1,0 +1,29 @@
+'use strict';
+
+let handlers = [ ];
+
+const on_interrupt = (cb) => {
+  handlers.push(cb);
+};
+
+const run_handlers = () => {
+  if (handlers.length === 0) {
+    process.exit(0);
+  } else {
+    setImmediate(() => handlers.shift()(run_handlers));
+  }
+};
+
+const shutdown = () => {
+  process.removeAllListeners('SIGTERM');
+  process.removeAllListeners('SIGINT');
+  process.on('SIGTERM', () => process.exit(1));
+  process.on('SIGINT', () => process.exit(1));
+
+  run_handlers();
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+
+module.exports = { on_interrupt };

--- a/cli/src/utils/start_rdb_server.js
+++ b/cli/src/utils/start_rdb_server.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const each_line_in_pipe = require('./each_line_in_pipe');
+const interrupt = require('./interrupt');
 const logger = require('@horizon/server').logger;
 
 const child_process = require('child_process');
@@ -39,8 +40,33 @@ module.exports = (raw_options) => {
       reject(err);
       process.exit(1);
     });
+
+    interrupt.on_interrupt((done) => {
+      if (rdbProc.exitCode === null) {
+        let finished = false;
+        rdbProc.kill('SIGTERM');
+
+        rdbProc.once('exit', () => {
+          if (!finished) {
+            finished = true;
+            done();
+          }
+        });
+
+        setTimeout(() => {
+          if (!finished) {
+            finished = true;
+            done();
+          }
+        }, 20000).unref();
+      }
+    });
+
     process.on('exit', () => {
-      rdbProc.kill('SIGTERM');
+      if (rdbProc.exitCode === null) {
+        logger.error('Unclean shutdown - killing RethinkDB child process');
+        rdbProc.kill('SIGKILL');
+      }
     });
 
     const maybe_resolve = () => {


### PR DESCRIPTION
Addresses issue #167.

The problem, as I diagnosed it, was that we were exiting before our child `rethinkdb` process was done.  In some situations, this is not a problem, but since we had piped in `rethinkdb`'s `stdin` and `stdout` (the default `child_process.spawn()` behavior), this resulted in the `rethinkdb` process hanging during shutdown, and it would no longer respond to signals except for `SIGKILL`.  This was observed by changing the `child_process.spawn()` options to `{ stdio: 'inherit' }` and observing that the child process would no longer hang.

The fix is to wait for `rethinkdb` to exit before exiting ourselves, and/or to kill it with `SIGKILL` if we have to exit immediately.  I added a new file in `utils/interrupt.js` to manage behavior that needs to happen on `SIGINT` and `SIGTERM`.  When we launch `rethinkdb` we add a handler that will attempt to shut it down with `SIGTERM` when the CLI is interrupted, and registers a timer failsafe to continue with shutdown after 20 seconds, regardless.  If we are exiting the CLI and the `rethinkdb` child process is still running, we will kill it with `SIGKILL`.

During this implementation, I found some other problems with orderly shutdown that have also been fixed in this branch.  Namely, the Horizon server's connection attempts to `rethinkdb` were not stopped properly on `server.close()`, and the CLI was not closing the HTTP listeners.
