### PR TITLE
Upping the required version of RethinkDB to 2.3.0

### DIFF
--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -2,7 +2,7 @@
 
 const logger = require('./logger');
 
-const MIN_VERSION = [ 2, 2, 5 ];
+const MIN_VERSION = [ 2, 3, 0 ];
 
 // Recursive version compare, could be flatter but opted for instant return if
 //  comparison is greater rather than continuing to compare to end.


### PR DESCRIPTION
:two::three::zero:
