### PR TITLE
Update help string for hz serve --dev to show correct flags

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -79,10 +79,10 @@ const addArguments = (parser) => {
       help: 'Runs the server in development mode, this sets ' +
       '--debug, ' +
       '--insecure, ' +
-      '--auto-create-tables, ' +
+      '--auto-create-table, ' +
       '--start-rethinkdb, ' +
       '--serve-static, ' +
-      'and --auto-create-indexes.' });
+      'and --auto-create-index.' });
 
   parser.addArgument([ '--config' ],
     { type: 'string', metavar: 'PATH',


### PR DESCRIPTION
Currently the help output `hz serve --help` suggests that running with the `--dev` flag is the same a running the flags below.

```
  --dev                 Runs the server in development mode, this sets
                        --debug, --insecure, --auto-create-tables,
                        --start-rethinkdb, --serve-static, and
                        --auto-create-indexes.
```

The `--auto-create-indexes` flag should read `--auto-create-index`, and `--auto-create-tables` should read `--auto-create-table` to match the actual flags.
