### PR TITLE
Adding `hz version` command

### DIFF
--- a/cli/src/main.js
+++ b/cli/src/main.js
@@ -4,6 +4,7 @@
 const argparse = require('argparse');
 const initCommand = require('./init.js');
 const serveCommand = require('./serve.js');
+const versionCommand = require('./version.js');
 
 const parser = new argparse.ArgumentParser();
 
@@ -20,6 +21,11 @@ const initParser = subparsers.addParser('init', {
 const serveParser = subparsers.addParser('serve', {
   addHelp: true,
   help: 'Serve a horizon app',
+});
+
+const versionParser = subparsers.addParser('version', {
+  addHelp: true,
+  help: 'Print the verison number of horizon',
 });
 
 initCommand.addArguments(initParser);
@@ -46,6 +52,10 @@ case 'init': {
 case 'serve': {
   const options = serveCommand.processConfig(parsed);
   serveCommand.runCommand(options, done_cb(options));
+  break;
+}
+case 'version': {
+  versionCommand.runCommand();
   break;
 }
 }

--- a/cli/src/version.js
+++ b/cli/src/version.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const package_json = require('../package.json');
+
+const runCommand = () => {
+  console.log(package_json.version);
+};
+
+module.exports = {
+  runCommand,
+};


### PR DESCRIPTION
Should have a quick and easy way to determine which version of `hz` you have installed. Just logs what the version is in `package.json`.

Satisfies #236 
