### PR TITLE
Add `hz create-cert` command (resolves #221)

### DIFF
--- a/cli/src/create-cert.js
+++ b/cli/src/create-cert.js
@@ -1,0 +1,58 @@
+'use strict';
+const hasbin = require('hasbin');
+const spawn = require('child_process').spawn;
+const runCommand = () => {
+  // TODO: user configuration?
+  const settings = {
+    binaryName: 'openssl',
+    keyOutName: 'horizon-key.pem',
+    certOutName: 'horizon-cert.pem',
+    algo: 'rsa',
+    bits: '2048',
+    days: '365',
+  };
+
+  // generate the arguments to the command
+  const binArgs = [ 'req', '-x509', '-nodes', '-batch',
+    '-newkey', `${settings.algo}:${settings.bits}`,
+    '-keyout', settings.keyOutName,
+    '-out', settings.certOutName,
+    '-days', settings.days,
+  ];
+
+  hasbin(settings.binaryName, function(hasOpenSSL) {
+    // show the invocation that's about to be run
+    console.log(`> ${settings.binaryName} ${binArgs.join(' ')}`);
+    // if we don't have openssl, bail
+    if (!hasOpenSSL) {
+      return console.error(`Missing ${settings.binaryName}. Make sure it is on the path.`);
+    }
+
+    // otherwise start openssl
+    const sslProc = spawn(settings.binaryName, binArgs);
+
+    // pipe output appropriately
+    sslProc.stdout.pipe(process.stdout, { end: false });
+    sslProc.stderr.pipe(process.stderr, { end: false });
+
+    // and say nice things to the user when it's done
+    sslProc.on('close', (code) => {
+      console.log(`OpenSSL exited with code ${code}.`);
+      if (code) {
+        return console.error(
+          'Something seems to have gone wrong; ' +
+          'check the output above for details.'
+        );
+      } else {
+        return console.log(
+          'Everything seems to be fine. ' +
+          'Remember to add your shiny new certificates to your Horizon config!'
+        );
+      }
+    });
+  });
+};
+
+module.exports = {
+  runCommand,
+};

--- a/cli/src/main.js
+++ b/cli/src/main.js
@@ -5,6 +5,7 @@ const argparse = require('argparse');
 const initCommand = require('./init.js');
 const serveCommand = require('./serve.js');
 const versionCommand = require('./version.js');
+const createCertCommand = require('./create-cert.js');
 
 const parser = new argparse.ArgumentParser();
 
@@ -26,6 +27,11 @@ const serveParser = subparsers.addParser('serve', {
 const versionParser = subparsers.addParser('version', {
   addHelp: true,
   help: 'Print the verison number of horizon',
+});
+
+const createCertParser = subparsers.addParser('create-cert', {
+  addHelp: true,
+  help: 'Generate a certificate',
 });
 
 initCommand.addArguments(initParser);
@@ -56,6 +62,10 @@ case 'serve': {
 }
 case 'version': {
   versionCommand.runCommand();
+  break;
+}
+case 'create-cert': {
+  createCertCommand.runCommand();
   break;
 }
 }


### PR DESCRIPTION
Chasing away those spooks 👻, one step at a time.

Sample output of running `hz create-cert`:

```
Robs-MacBook-Pro:tmp rob$ hz create-cert
> openssl req -x509 -newkey rsa:2048 -keyout horizon-key.pem -out horizon-cert.pem -days 365 -nodes -batch
Generating a 2048 bit RSA private key
..........+++
..............+++
writing new private key to 'horizon-key.pem'
-----
OpenSSL exited with code 0.
Everything seems to be fine. Remember to add your shiny new certificates to your Horizon config!
```
