### PR TITLE
resolves #261 Add logic to better detect project directory

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -433,23 +433,15 @@ const runCommand = (opts, done) => {
 
   if (opts.project !== null) {
     try {
+      if (!fs.statSync('.hz').isDirectory()) {
+        throw new Error();
+      }
+    } catch (e) {
       process.chdir(opts.project);
-    } catch (err) {
-      console.error(`Failed to find "${opts.project}" project directory`);
-      process.exit(1);
     }
-  }
-  // Check for .hz directory
-  try {
-    if (!fs.statSync('.hz').isDirectory()) {
-      throw new Error();
-    }
-  } catch (e) {
-    if (opts.project == null) {
-      console.error('There is no .hz directory here');
-    } else {
-      console.error(`There is no .hz directory in ${opts.project}`);
-    }
+  } else {
+    console.error('Project not specified or .hz directory not found.\nTry changing to a project' +
+      ' with a .hz directory,\nor specify your project path with the --project option');
     process.exit(1);
   }
 


### PR DESCRIPTION
I cleaned up the logic for checking if we're in a horizon project directory, and reworded the error message. `opts.project` gets set first from `config.toml`, then env and last cli args. If none of those are set it should fail immediately, otherwise `cd` into the project directory if we don't already have a `.hz` directory.

The existing tests still pass, and I didn't see anything specific to this particular case. I'm happy to try to add some before this gets merged.
