### PR TITLE
move connection and auth constants to separate file

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,6 @@
-* If you have a **question** please open a new topic in Horizon's [Get Help](https://discuss.horizon.io/c/get-help) forum.
-* If you want to suggest a **feature**, consider discussing it in [Features](https://discuss.horizon.io/c/features) first
+If you have a question,  please open a new topic in Horizon's Help forum:
+    https://discuss.horizon.io/c/get-help
+    
+If you're suggesting a feature but aren't sure how it might be implemented, we have a more free-form discussion forum for features:
+    https://discuss.horizon.io/c/features
 
-If you have a bug report, fire away!

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -1,8 +1,7 @@
 const queryParse = require('./util/query-parse')
+const constants = require('./constants').auth
 const Rx = require('rx')
 require('rx-dom-ajax') // add Rx.DOM.ajax methods
-
-const HORIZON_JWT = 'horizon-jwt'
 
 /** @this Horizon **/
 function authEndpoint(name) {
@@ -50,21 +49,21 @@ function getStorage() {
 }
 
 class TokenStorage {
-  constructor(authType = 'unauthenticated') {
+  constructor(authType = constants.TYPE_UNAUTHENTICATED) {
     this._storage = getStorage()
     this._authType = authType
   }
 
   set(jwt) {
-    return this._storage.setItem(HORIZON_JWT, jwt)
+    return this._storage.setItem(constants.HORIZON_JWT, jwt)
   }
 
   get() {
-    return this._storage.getItem(HORIZON_JWT)
+    return this._storage.getItem(constants.HORIZON_JWT)
   }
 
   remove() {
-    return this._storage.removeItem(HORIZON_JWT)
+    return this._storage.removeItem(constants.HORIZON_JWT)
   }
 
   setAuthFromQueryParams() {
@@ -80,8 +79,8 @@ class TokenStorage {
     // new one
     const token = this.get()
     if (token != null) {
-      return { method: 'token', token }
-    } else if (this._authType === 'token') {
+      return { method: constants.TYPE_TOKEN, token }
+    } else if (this._authType === constants.TYPE_TOKEN) {
       throw new Error(
         'Attempting to authenticate with a token, but no token is present')
     } else {
@@ -96,7 +95,7 @@ class TokenStorage {
 }
 
 function clearAuthTokens() {
-  return getStorage().removeItem(HORIZON_JWT)
+  return getStorage().removeItem(constants.HORIZON_JWT)
 }
 
 module.exports = {

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,0 +1,22 @@
+module.exports = {
+  connection: {
+    PROTOCOL_VERSION: 'rethinkdb-horizon-v0',
+    // Before connecting the first time
+    STATUS_UNCONNECTED: { type: 'unconnected' },
+    // After websocket is opened, but before handshake
+    STATUS_CONNECTED: { type: 'connected' },
+    // After websocket is opened and handshake is completed
+    STATUS_READY: { type: 'ready' },
+    // After unconnected, maybe before or after connected.
+    // Any socket level error
+    STATUS_ERROR: { type: 'error' },
+    // When the socket closes
+    STATUS_DISCONNECTED: { type: 'disconnected' },
+  },
+  auth: {
+    TYPE_UNAUTHENTICATED: 'unauthenticated',
+    TYPE_ANONYMOUS: 'anonymous',
+    TYPE_TOKEN: 'token',
+    HORIZON_JWT: 'horizon-jwt',
+  },
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -77,10 +77,6 @@ function Horizon({
       x.type === constants.connection.STATUS_READY.type
   ))
 
-  // Convenience method for finding out when ready
-  horizon.onReady = subscribeOrObservable(
-    socket.status.filter(x => x.type === 'ready'))
-
   // Convenience method for finding out when an error occurs
   horizon.onSocketError = subscribeOrObservable(
     socket.status.filter(x =>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,4 +1,5 @@
 const Rx = require('rx')
+const constants = require('./constants')
 const { Collection } = require('./ast')
 const HorizonSocket = require('./socket')
 const { log, logError, enableLogging } = require('./logging')
@@ -14,7 +15,7 @@ function Horizon({
   secure = defaultSecure,
   path = 'horizon',
   lazyWrites = false,
-  authType = 'unauthenticated',
+  authType = constants.auth.TYPE_UNAUTHENTICATED,
 } = {}) {
   // If we're in a redirection from OAuth, store the auth token for
   // this user in localStorage.
@@ -60,19 +61,27 @@ function Horizon({
 
   // Convenience method for finding out when disconnected
   horizon.onDisconnected = subscribeOrObservable(
-    socket.status.filter(x => x.type === 'disconnected'))
+    socket.status.filter(x =>
+      x.type === constants.connection.STATUS_DISCONNECTED.type
+  ))
 
   // Convenience method for finding out when opening
   horizon.onConnected = subscribeOrObservable(
-    socket.status.filter(x => x.type === 'connected'))
+    socket.status.filter(x =>
+      x.type === constants.connection.STATUS_CONNECTED.type
+  ))
 
   // Convenience method for finding out when ready
   horizon.onReady = subscribeOrObservable(
-    socket.status.filter(x => x.type === 'ready'))
+    socket.status.filter(x =>
+      x.type === constants.connection.STATUS_READY.type
+  ))
 
   // Convenience method for finding out when an error occurs
   horizon.onSocketError = subscribeOrObservable(
-    socket.status.filter(x => x.type === 'error'))
+    socket.status.filter(x =>
+      x.type === constants.connection.STATUS_ERROR.type
+  ))
 
   horizon._authMethods = null
   horizon._horizonPath = path
@@ -116,6 +125,7 @@ function subscribeOrObservable(observable) {
 
 Horizon.log = log
 Horizon.logError = logError
+Horizon.constants = constants
 Horizon.enableLogging = enableLogging
 Horizon.Socket = HorizonSocket
 Horizon.clearAuthTokens = clearAuthTokens

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -2,6 +2,7 @@
 
 const check = require('./error').check;
 const logger = require('./logger');
+const constants = require('@horizon/client/lib/constants').auth;
 const schemas = require('./schema/horizon_protocol');
 
 const Joi = require('joi');
@@ -193,7 +194,7 @@ class Client {
         metadata.get_user_info(decoded.user, (rdb_err, res) => {
           if (rdb_err) {
             this.send_response(request.request_id, { error: 'User does not exist.', error_code: 0 });
-            this.socket.close(1002, `Invalid user.`);
+            this.socket.close(1002, 'Invalid user.');
           } else {
             // TODO: listen on feed
             success(res, token);
@@ -205,13 +206,13 @@ class Client {
     };
 
     switch (request.method) {
-    case 'token':
+    case constants.TYPE_TOKEN:
       this.parent._auth.verify_jwt(request.token, done);
       break;
-    case 'anonymous':
+    case constants.TYPE_ANONYMOUS:
       this.parent._auth.generate_anon_jwt(done);
       break;
-    case 'unauthenticated':
+    case constants.TYPE_UNAUTHENTICATED:
       this.parent._auth.generate_unauth_jwt(done);
       break;
     default:

--- a/server/src/schema/horizon_protocol.js
+++ b/server/src/schema/horizon_protocol.js
@@ -1,12 +1,20 @@
 'use strict';
 
 const Joi = require('joi');
+const constants = require('@horizon/client/lib/constants').auth;
 
 const handshake = Joi.object().keys({
   request_id: Joi.number().required(),
-  method: Joi.only('token', 'anonymous', 'unauthenticated').required(),
+  method: Joi.only(
+    constants.TYPE_TOKEN,
+    constants.TYPE_ANONYMOUS,
+    constants.TYPE_UNAUTHENTICATED
+  ).required(),
   token: Joi.string().required()
-    .when('method', { is: Joi.not('token').required(), then: Joi.forbidden() }),
+    .when('method', {
+      is: Joi.not(constants.TYPE_TOKEN).required(),
+      then: Joi.forbidden(),
+    }),
 }).unknown(false);
 
 const read = Joi.alternatives().try(


### PR DESCRIPTION
This PR moves constants to a separate file so they can be easily used anywhere and not only in one place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/286)
<!-- Reviewable:end -->
