### PR TITLE
Match TOML example cert names to hz create-cert names

### DIFF
--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -42,8 +42,8 @@ const makeDefaultConfig = (projectName) => `\
 # 'key_file' and 'cert_file' are required for serving HTTPS
 #------------------------------------------------------------------------------
 # insecure = true
-# key_file = "key.pem"
-# cert_file = "cert.pem"
+# key_file = "horizon-key.pem"
+# cert_file = "horizon-cert.pem"
 
 
 ###############################################################################


### PR DESCRIPTION
The `hz create-cert` command creates the files `horizon-key.pem` and `horizon-cert.pem`; it'd be better if the TOML file that `hz init` creates uses these names in its comments, so if you're using the created certificates, you can just uncomment those lines without modifying them.
