### PR TITLE
Add missing comma in store example

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -259,7 +259,7 @@ To store documents into the collection, we use [`.store`][store].
 // Object being stored
 let message = {
   text: "What a beautiful horizon 🌄!",
-  datetime: new Date()
+  datetime: new Date(),
   author: "@dalanmiller"
 }
 


### PR DESCRIPTION
Fixed the `store` example by adding a missing comma.
