### PR TITLE
Clean up horizon cli output

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@horizon/server": "^0.1.1-0",
     "argparse": "^1.0.3",
+    "chalk": "^1.1.3",
     "hasbin": "^1.2.1",
     "toml": "^2.3.0"
   },


### PR DESCRIPTION
This fixes #296 

The output for Horizon looks much cleaner in several situations.

Happy path:
![selection_085](https://cloud.githubusercontent.com/assets/1366/15202395/bc674fca-17ae-11e6-85de-7f123fbf919e.png)

If the user specified --insecure but not as part of --dev:

![selection_086](https://cloud.githubusercontent.com/assets/1366/15202410/e4c29344-17ae-11e6-9fcf-186281002fa6.png)

If the server fails to start within 30 seconds for whatever reason (in this case because they had no rethinkdb server running):

![selection_087](https://cloud.githubusercontent.com/assets/1366/15202433/2a1c95f2-17af-11e6-8dee-7a7b09a0ce87.png)
