### PR TITLE
Refactor auth to use promises, expose user profile in handshake

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -22,9 +22,10 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "joi": "^8.0.4",
     "@horizon/client": "0.1.1-0",
+    "bluebird": "^3.3.5",
     "cookie": "^0.2.3",
+    "joi": "^8.0.4",
     "jsonwebtoken": "^5.5.4",
     "oauth": "^0.9.14",
     "pem": "^1.8.1",

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -24,60 +24,58 @@ class Auth {
   constructor(server, user_options) {
     const options = Joi.attempt(user_options, options_schema);
 
+    this._jwt = new JWT(options);
+
     this._success_redirect = url.parse(options.success_redirect);
     this._failure_redirect = url.parse(options.failure_redirect);
-    this._duration = options.duration;
     this._create_new_users = options.create_new_users;
     this._new_user_group = options.new_user_group;
     this._allow_anonymous = options.allow_anonymous;
     this._allow_unauthenticated = options.allow_unauthenticated;
 
     this._parent = server;
+  }
 
-    if (options.token_secret != null) {
-      this._hmac_secret = new Buffer(options.token_secret, 'base64');
-    } else {
-      throw new Error(
-        'No token_secret set! ' +
-        'Try setting it in .hz/config.toml or passing it ' +
-        'to the Server constructor.');
+  handshake(request) {
+    switch (request.method) {
+      case 'token':
+        return this._jwt.verify(request.token);
+      case 'unauthenticated':
+        if (!this._allow_unauthenticated) {
+          throw new Error('Unauthenticated connections are not allowed.');
+        }
+        return this._jwt.verify(this._jwt.sign(request.method));
+      case 'anonymous':
+        if (!this._allow_anonymous) {
+          throw new Error('Anonymous connections are not allowed.');
+        }
+        return this.generate(request.method, r.uuid());
+      default:
+        throw new Error(`Unknown handshake method "${request.method}"`);
     }
   }
 
-  // A generated token contains the data:
-  // { user: <uuid>, provider: <string> }
-  _jwt_from_user(user, provider) {
-    return jwt.sign(
-      { user, provider },
-      this._hmac_secret,
-      { expiresIn: this._duration,
-        algorithm: 'HS512' }
-    );
-  }
-
   // TODO: maybe we should write something into the user data to track open sessions/tokens
-  generate_jwt(provider, info) {
-    const key = auth_key(provider, info);
-    let query = r.db('horizon_internal').table('users_auth').get(key);
+  generate(provider, id) {
+    const key = auth_key(provider, id);
+    const auth_table = r.db('horizon_internal').table('users_auth');
+    const users_table = r.db('horizon_internal').table('users');
+
+    function insert(table, row) {
+      return table
+        .insert(row, { conflict: 'error', returnChanges: 'always' })
+        .bracket('changes')(0)('new_val');
+    }
+
+    let query = auth_table.get(key);
 
     if (this._create_new_users) {
-      query = query.default(r.uuid().do((user_id) =>
-                r.db('horizon_internal').table('users_auth').insert({ id: key, user_id },
-                                                                   { returnChanges: true })
-                 .do((res) =>
-                   r.branch(res('inserted').eq(1),
-                     r.db('horizon_internal').table('users')
-                      .insert({ id: user_id, groups: [ this._new_user_group ] })
-                      .do((res2) =>
-                        r.branch(res2('inserted').eq(1),
-                          res('changes')(0)('new_val'),
-                          r.error(res2('first_error'))
-                        )),
-                     r.error(res('first_error'))
-                   )
-                 )
-             ));
-    } else {
+      query = insert(auth_table, { id: key, user_id: r.uuid() })
+        .do(auth =>
+          insert(users_table, { id: auth('user_id'), groups: [ this._new_user_group ] })
+        );
+    }
+    else {
       query = query.default(r.error('User not found and new user creation is disabled.'));
     }
 
@@ -88,47 +86,11 @@ class Auth {
       logger.debug(`Failed user lookup or creation: ${err}`);
       throw new Error('User lookup or creation in database failed.');
     })
-    .then(res => {
-      return this._jwt_from_user(res.user_id, provider);
-    });
-  }
-
-  generate_anon_jwt() {
-    const query = r.db('horizon_internal').table('users')
-                   .insert({ group: this._new_user_group });
-
-    return this.reql_call(query)
-    .catch(err => {
-      logger.debug(`Failed anonymous user creation: ${err}`);
-      throw new Error('Anonymous user creation in database failed.');
-    })
-    .then(res => {
-      return this.verify_jwt(this._jwt_from_user(res.generated_keys[0], null));
-    });
-  }
-
-  generate_unauth_jwt() {
-    return this.verify_jwt(this._jwt_from_user(null, null));
-  }
-
-  verify_jwt(token) {
-    return jwt.verifyAsync(token, this._hmac_secret, { algorithms: [ 'HS512' ] })
-    .then(decoded => {
-      if (decoded.user === undefined || decoded.provider === undefined) {
-        throw new Error('Invalid token data, "user" and "provider" must be specified.');
-      }
-      if (decoded.provider === null) {
-        if (decoded.user === null) {
-          if (!this._allow_unauthenticated) {
-            throw new Error('Unauthenticated connections are not allowed.');
-          }
-        } else if (!this._allow_anonymous) {
-          throw new Error('Anonymous connections are not allowed.');
-        }
-      }
-
-      decoded.token = token;
-      return decoded;
+    .then(user => {
+      this._jwt.sign(provider, user.id).then(token => {
+        token.user = user;
+        return token;
+      })
     });
   }
 
@@ -137,6 +99,39 @@ class Auth {
       return Promise.reject('Connection to database is down, cannot perform authentication.');
     }
     return query.run(this._parent._reql_conn.connection());
+  }
+}
+
+class JWT {
+  constructor(options) {
+    this.duration = options.duration;
+    this.algorithm = 'HS512';
+
+    if (options.token_secret != null) {
+      this.secret = new Buffer(options.token_secret, 'base64');
+    } else {
+      throw new Error(
+        'No token_secret set! Try setting it in .hz/config.toml' +
+        'or passing it to the Server constructor.');
+    }
+  }
+
+  // A generated token contains the data:
+  // { user: <uuid>, provider: <string> }
+  sign(provider, user) {
+    return jwt.sign(
+      { user, provider },
+      this.secret,
+      { algorithm: this.algorithm, expiresIn: this.duration }
+    );
+  }
+
+  verify(token) {
+    return jwt.verifyAsync(token, this.secret, { algorithms: [ this.algorithm ] })
+    .then(decoded => {
+      decoded.token = token;
+      return decoded;
+    });
   }
 }
 

--- a/server/src/auth/twitter.js
+++ b/server/src/auth/twitter.js
@@ -121,7 +121,7 @@ function twitter(horizon, raw_options) {
                 logger.error(`Bad JSON data from oauth API: ${body}`);
                 auth_utils.do_redirect(res, make_failure_url('unparseable inspect response'));
               } else {
-                horizon._auth.generate_jwt(provider, user_id).nodeify((err3, jwt) => {
+                horizon._auth.generate(provider, user_id).nodeify((err3, jwt) => {
                   auth_utils.clear_nonce(res, horizon._name);
                   auth_utils.do_redirect(res, err3 ?
                     make_failure_url('invalid user') :

--- a/server/src/auth/twitter.js
+++ b/server/src/auth/twitter.js
@@ -121,7 +121,7 @@ function twitter(horizon, raw_options) {
                 logger.error(`Bad JSON data from oauth API: ${body}`);
                 auth_utils.do_redirect(res, make_failure_url('unparseable inspect response'));
               } else {
-                horizon._auth.generate_jwt(provider, user_id, (err3, jwt) => {
+                horizon._auth.generate_jwt(provider, user_id).nodeify((err3, jwt) => {
                   auth_utils.clear_nonce(res, horizon._name);
                   auth_utils.do_redirect(res, err3 ?
                     make_failure_url('invalid user') :

--- a/server/src/auth/utils.js
+++ b/server/src/auth/utils.js
@@ -172,7 +172,7 @@ const oauth2 = (raw_options) => {
                 res.statusCode = 500;
                 res.end('unparseable inspect response');
               } else {
-                horizon._auth.generate_jwt(provider, user_id, (err3, jwt) => {
+                horizon._auth.generate_jwt(provider, user_id).nodeify((err3, jwt) => {
                   // Clear the nonce just so we aren't polluting clients' cookies
                   clear_nonce(res, horizon._name);
                   do_redirect(res, err3 ?

--- a/server/src/auth/utils.js
+++ b/server/src/auth/utils.js
@@ -172,7 +172,7 @@ const oauth2 = (raw_options) => {
                 res.statusCode = 500;
                 res.end('unparseable inspect response');
               } else {
-                horizon._auth.generate_jwt(provider, user_id).nodeify((err3, jwt) => {
+                horizon._auth.generate(provider, user_id).nodeify((err3, jwt) => {
                   // Clear the nonce just so we aren't polluting clients' cookies
                   clear_nonce(res, horizon._name);
                   do_redirect(res, err3 ?

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -157,16 +157,14 @@ class Client {
     try {
       return Joi.attempt(request, schema);
     } catch (err) {
-      const req_id = request.request_id === undefined ? null : request.request_id;
-
-      const detail = err.details[0];
-      const err_str = `Request validation error at "${detail.path}": ${detail.message}`;
-      this.send_response(req_id, { error: err_str, error_code: 0 });
-
       if (request.request_id === undefined) {
         // This is pretty much an unrecoverable protocol error, so close the connection
         return this.close_socket('Protocol error.', err);
       }
+
+      const detail = err.details[0];
+      const err_str = `Request validation error at "${detail.path}": ${detail.message}`;
+      this.send_response(request.request_id, { error: err_str, error_code: 0 });
     }
   }
 
@@ -174,50 +172,45 @@ class Client {
     const request = this.parse_request(data, schemas.handshake);
 
     if (request === undefined) {
-      return this.close_socket('Invalid handshake.');
+      this.close_socket('Invalid handshake.');
+      return;
     }
 
-    const success = (user_info, token) => {
-      this.user_info = user_info;
+    const verify_or_generate = () => {
+      switch (request.method) {
+      case 'token':
+        return this.parent._auth.verify_jwt(request.token);
+      case 'anonymous':
+        return this.parent._auth.generate_anon_jwt();
+      case 'unauthenticated':
+        return this.parent._auth.generate_unauth_jwt();
+      default:
+        return Promise.reject(`Unknown handshake method "${request.method}"`);
+      }
+    }
+
+    verify_or_generate()
+    .then(token => {
+      if (token.user === null) return token;
+
+      const metadata = this.parent._reql_conn.metadata();
+      return metadata.get_user_info(token.user)
+      .then(user => {
+        token.user = user;
+        return token;
+      })
+      .catch(err => throw new Error('User does not exist.'));
+    })
+    .then(token => {
+      this.user_info = token.user;
+      this.send_response(request.request_id, token);
       this.socket.on('message', (data) =>
         this.error_wrap_socket(() => this.handle_request(data)));
-      this.send_response(request.request_id, { token });
-    };
-
-    const done = (err, token, decoded) => {
-      if (err) {
-        this.send_response(request.request_id, { error: `${err}`, error_code: 0 });
-        this.close_socket('Invalid token.', err);
-      } else if (decoded.user !== null) {
-        const metadata = this.parent._reql_conn.metadata();
-        metadata.get_user_info(decoded.user, (rdb_err, res) => {
-          if (rdb_err) {
-            this.send_response(request.request_id, { error: 'User does not exist.', error_code: 0 });
-            this.socket.close(1002, `Invalid user.`);
-          } else {
-            // TODO: listen on feed
-            success(res, token);
-          }
-        });
-      } else {
-        success(null, token);
-      }
-    };
-
-    switch (request.method) {
-    case 'token':
-      this.parent._auth.verify_jwt(request.token, done);
-      break;
-    case 'anonymous':
-      this.parent._auth.generate_anon_jwt(done);
-      break;
-    case 'unauthenticated':
-      this.parent._auth.generate_unauth_jwt(done);
-      break;
-    default:
-      this.close_socket('Unknown method.', `Unknown handshake method "${request.method}"`);
-      break;
-    }
+    })
+    .catch(err => {
+      this.send_response(request.request_id, { error: `${err}`, error_code: 0 });
+      this.close_socket('Invalid token.', err);
+    })
   }
 
   handle_request(data) {

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -178,7 +178,7 @@ class Client {
 
     this.parent._auth.handshake(request)
     .then(token => {
-      this.user_info = token.user;
+      this.user_info = token.payload;
       this.send_response(request.request_id, token);
       this.socket.on('message', (data) =>
         this.error_wrap_socket(() => this.handle_request(data)));

--- a/server/src/metadata.js
+++ b/server/src/metadata.js
@@ -159,7 +159,7 @@ class Metadata {
       query = r.expr([ 'horizon', 'horizon_internal' ])
        .forEach((db) => r.branch(r.dbList().contains(db), [], r.dbCreate(db)))
        .do(() =>
-         r.expr([ 'collections', 'users_auth', 'users' ])
+         r.expr([ 'collections', 'users' ])
           .forEach((table) => r.branch(r.db('horizon_internal').tableList().contains(table),
                                        [], r.db('horizon_internal').tableCreate(table)))
           .do(() => query));

--- a/server/src/metadata.js
+++ b/server/src/metadata.js
@@ -250,8 +250,8 @@ class Metadata {
     });
   }
 
-  get_user_info(id, done) {
-    r.db('horizon_internal').table('users').get(id).run(this._conn, done);
+  get_user_info(id) {
+    return r.db('horizon_internal').table('users').get(id).run(this._conn);
   }
 }
 

--- a/server/test/protocol_tests.js
+++ b/server/test/protocol_tests.js
@@ -25,7 +25,7 @@ const all_tests = (table) => {
     conn.send('{ }');
     conn.once('close', (code, msg) => {
       assert.strictEqual(code, 1002);
-      assert.strictEqual(msg, 'Invalid request.');
+      assert.strictEqual(msg, 'Protocol error.');
       done();
     });
   });

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -56,7 +56,8 @@ const create_table = (table, done) => {
       conn.once('message', (data) => {
         const response = JSON.parse(data);
         assert.equal(response.request_id, 123);
-        assert.equal(response.provider, 'unauthenticated');
+        assert.equal(response.payload.provider, 'unauthenticated');
+        assert(response.token);
 
         // This query should auto-create the table if it's missing
         conn.send(JSON.stringify({
@@ -181,7 +182,8 @@ const horizon_auth = (req, cb) => {
 const horizon_default_auth = (done) => {
   horizon_auth({ request_id: -1, method: 'unauthenticated' }, (res) => {
     assert.equal(res.request_id, -1);
-    assert.equal(res.provider, 'unauthenticated');
+    assert.equal(res.payload.provider, 'unauthenticated');
+    assert(res.token);
     done();
   });
 };

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -55,7 +55,8 @@ const create_table = (table, done) => {
       conn.send(JSON.stringify({ request_id: 123, method: 'unauthenticated' }));
       conn.once('message', (data) => {
         const response = JSON.parse(data);
-        assert.deepStrictEqual(response, { request_id: 123, token: response.token });
+        assert.equal(response.request_id, 123);
+        assert.equal(response.provider, 'unauthenticated');
 
         // This query should auto-create the table if it's missing
         conn.send(JSON.stringify({
@@ -179,7 +180,8 @@ const horizon_auth = (req, cb) => {
 
 const horizon_default_auth = (done) => {
   horizon_auth({ request_id: -1, method: 'unauthenticated' }, (res) => {
-    assert.deepStrictEqual(res, { request_id: -1, token: res.token });
+    assert.equal(res.request_id, -1);
+    assert.equal(res.provider, 'unauthenticated');
     done();
   });
 };


### PR DESCRIPTION
Exposes the user's profile to the client in the handshake response (which will be necessary for #3 and/or #151). Other than that, this is mostly just cleaning up some nested callbacks in favor of Promises.