### PR TITLE
require isomorphic-fetch with imports & exports loader to make it work everywhere #352 #255

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,8 @@
     "chai": "^3.5.0",
     "copy-webpack-plugin": "^1.1.1",
     "eslint": "2.2.x",
+    "exports-loader": "^0.6.3",
+    "imports-loader": "^0.6.5",
     "istanbul": "^0.4.2",
     "lodash": "^4.6.1",
     "mocha": "2.3.4",

--- a/client/src/util/fetch.js
+++ b/client/src/util/fetch.js
@@ -1,7 +1,9 @@
 import { Observable } from 'rxjs/Observable'
 import { fromPromise } from 'rxjs/observable/fromPromise'
 import { map } from 'rxjs/operator/map'
-import fetch from 'isomorphic-fetch'
+
+global.self = global
+require('imports?this=>global!exports?global.fetch!isomorphic-fetch')
 
 export default function fetchJSON(url) {
   return Observable::fromPromise(fetch(url))


### PR DESCRIPTION
this makes the fetch code work in React Native & node too
