### PR TITLE
Update `hz init` config file template

### DIFF
--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -38,7 +38,7 @@ const makeDefaultConfig = (projectName) => `\
 
 ###############################################################################
 # HTTPS Options
-# 'secure = no' will disable HTTPS and use HTTP instead
+# 'secure' will disable HTTPS and use HTTP instead when set to `false`
 # 'key_file' and 'cert_file' are required for serving HTTPS
 #------------------------------------------------------------------------------
 # secure = false


### PR DESCRIPTION
The description of `project_name` was wrong.

Also `grey_permissions` replaces the `insecure` option with `secure`.

@deontologician, @Tryneus
