### PR TITLE
Implicit .anyRead() in templates

### DIFF
--- a/server/src/permissions/template.js
+++ b/server/src/permissions/template.js
@@ -230,7 +230,8 @@ class Template {
     if (!(this._value instanceof Any) && !(this._value instanceof AnyObject)) {
       if (this._value.request_id === undefined
           && this._value.type === undefined
-          && this._value.options === undefined) {
+          && this._value.options === undefined
+          && this._value.anyRead) {
         this._value = this._value.anyRead();
       }
       check(this._value.request_id !== undefined, incomplete_template_message(str));

--- a/server/test/permissions.js
+++ b/server/test/permissions.js
@@ -166,9 +166,22 @@ describe('Permissions', () => {
       assert(rule.is_match(make_request('query', 'test', { find: { owner: context.user_id } }), context));
     });
 
+    it('adds readAny() implicitly', () => {
+      {
+        const rule = new Rule('foo', { template: 'collection("test")' });
+        assert(rule.is_valid());
+        assert(rule.is_match(make_request('query', 'test', { find: { } }), context));
+        assert(rule.is_match(make_request('query', 'test', { find: { bar: 'baz' } }), context));
+      }
+      {
+        const rule = new Rule('foo', { template: 'collection("test").find({bar: any()})' });
+        assert(rule.is_valid());
+        assert(!rule.is_match(make_request('query', 'test', { find: { } }), context));
+        assert(rule.is_match(make_request('query', 'test', { find: { bar: 'baz' } }), context));
+      }
+    });
+
     it('error on incomplete template', () => {
-      assert.throws(() => new Rule('foo', { template: 'collection("test")' }), /Incomplete template/);
-      assert.throws(() => new Rule('foo', { template: 'collection("test").find(any())' }), /Incomplete template/);
       assert.throws(() => new Rule('foo', { template: '({ })' }), /Incomplete template/);
       assert.throws(() => new Rule('foo', { template: '[ ]' }), /Invalid template/);
       assert.throws(() => new Rule('foo', { template: '5' }), /Invalid template/);


### PR DESCRIPTION
Adds an implicit `.anyRead()` to templates if they don't end in a write or `.fetch()`/`.watch()`.

@Tryneus 
