### PR TITLE
Don't leak information from validator exceptions

### DIFF
--- a/server/src/permissions/validator.js
+++ b/server/src/permissions/validator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const check = require('../error').check;
+const logger = require('../logger');
 const remake_error = require('../utils').remake_error;
 
 const vm = require('vm');
@@ -19,7 +20,10 @@ class Validator {
     try {
       return this._fn.apply(this._fn, arguments);
     } catch (err) {
-      throw remake_error(err);
+      // We don't want to pass the error message on to the user because it might leak
+      // information about the data.
+      logger.error(`Exception in validator function: ${err.stack}`);
+      throw Error("Validation error");
     }
   }
 }


### PR DESCRIPTION
If a validator throws an exception, we now print that exception to the log but no longer pass it on to the client. Passing such an exception on to the client might leak information about data that the user is not permitted to access.

@Tryneus 
