### PR TITLE
Bumped server test timeout to 30s

### DIFF
--- a/server/test/test.js
+++ b/server/test/test.js
@@ -22,7 +22,7 @@ afterEach(
   function() { logger.info(`End test '${this.currentTest.title}'`); });
 
 describe('Horizon Server', function() {
-  this.timeout(10000);
+  this.timeout(30000);
   before('Start Horizon Server', utils.start_horizon_server);
   after('Close Horizon Server', utils.close_horizon_server);
 


### PR DESCRIPTION
I got a lot of timeouts when running the server test on my machine.
This bumps the mocha timeout to 30s per test.
