### PR TITLE
Pass on errors during metadata initialization

### DIFF
--- a/server/src/metadata.js
+++ b/server/src/metadata.js
@@ -231,8 +231,9 @@ class Metadata {
       // Redirect the 'users' table to the one in the internal db
       this._collections.set('users', new Collection({ id: 'users', table: 'users' },
                                                     this._internal_db, this._conn));
-    }).catch(() => {
+    }).catch((e) => {
       this.close();
+      throw e;
     });
   }
 


### PR DESCRIPTION
This seems to fix https://github.com/rethinkdb/horizon/issues/392

I'm not sure why this was working before the latest `admin` user change.
