### PR TITLE
fixing readiness in server metadata syncing

### DIFF
--- a/server/src/metadata.js
+++ b/server/src/metadata.js
@@ -234,7 +234,7 @@ class Metadata {
       logger.debug('metadata sync complete');
       this._ready = true;
       return this;
-    })
+    });
 
     this._ready_promise.catch(() => {
       this.close();

--- a/server/src/metadata.js
+++ b/server/src/metadata.js
@@ -184,7 +184,7 @@ class Metadata {
         r.expr([ this._db, this._internal_db ])
          .concatMap((db) => r.branch(r.dbList().contains(db), [], [db]))
          .run(this._conn).then((missing_dbs) => {
-           console.log("checking for internal db/tables");
+           logger.debug("checking for internal db/tables");
            if (missing_dbs.length > 0) {
              let err_msg;
              if (missing_dbs.length == 1) {


### PR DESCRIPTION
This does an alternate solution for #395, but also includes moving the `_ready` variable setting to true until we're actually fulfilling the promise - so nothing things we're good to go before we are.
