### PR TITLE
Make react-chat-app easy to run for new developers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,6 @@
+# For First-Time Developers
+See the [React Chat App](/examples/react-chat-app) which has step-by-step instructions to get it going.
+
 # Community Examples
 
 Coming soon!

--- a/examples/react-chat-app/.hz/config.toml
+++ b/examples/react-chat-app/.hz/config.toml
@@ -4,5 +4,3 @@ project_name = "react_chat_app"
 # But it makes the example app easier to run
 auto_create_collection = true
 auto_create_index = true
-
-token_secret = "nuQFOzmjgB7BGcgjcLNiGN7h4S3PjSNaFA/7KlKOuyogFC6kDo+gal/SZ76kWPfXjTEvP/XaK2ifQyqprMGxQA=="

--- a/examples/react-chat-app/.hz/config.toml
+++ b/examples/react-chat-app/.hz/config.toml
@@ -1,0 +1,8 @@
+project_name = "react_chat_app"
+
+# You probably don't want these options on a public server...
+# But it makes the example app easier to run
+auto_create_collection = true
+auto_create_index = true
+
+token_secret = "nuQFOzmjgB7BGcgjcLNiGN7h4S3PjSNaFA/7KlKOuyogFC6kDo+gal/SZ76kWPfXjTEvP/XaK2ifQyqprMGxQA=="

--- a/examples/react-chat-app/README.md
+++ b/examples/react-chat-app/README.md
@@ -2,6 +2,11 @@
 
 <center>![](https://i.imgur.com/XFostB8.gif)</center>
 
+## Running this example
+1) Install Horizon: "npm install -g horizon"
+2) Install RethinkDB: https://rethinkdb.com/docs/install/
+3) Run "horizon serve --dev" in this directory
+4) Open http://127.0.0.1:8181
 
 ## Ideas for future
 

--- a/examples/react-chat-app/README.md
+++ b/examples/react-chat-app/README.md
@@ -3,10 +3,10 @@
 <center>![](https://i.imgur.com/XFostB8.gif)</center>
 
 ## Running this example
-1) Install Horizon: "npm install -g horizon"
-2) Install RethinkDB: https://rethinkdb.com/docs/install/
-3) Run "horizon serve --dev" in this directory
-4) Open http://127.0.0.1:8181
+1. Install Horizon: "npm install -g horizon"
+2. Install RethinkDB: https://rethinkdb.com/docs/install/
+3. Run "horizon serve --dev" in this directory
+4. Open http://127.0.0.1:8181
 
 ## Ideas for future
 

--- a/examples/react-chat-app/dist/index.html
+++ b/examples/react-chat-app/dist/index.html
@@ -12,7 +12,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-with-addons.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js"></script>
   <script src="https://fb.me/JSXTransformer-0.13.3.js"></script>
-  <script src="://localhost:8181/horizon/horizon.js"></script>
   <script src="/horizon/horizon.js"></script>
   <script type="text/jsx" src="app.jsx"></script>
 


### PR DESCRIPTION
It took me about an hour to get my first working client/server example horizon app running. There's a lot of details to figure out, and the examples don't include .hz/config.toml files.

This makes one of the examples really easy to run, and points new developers toward that example.

I think this would save a lot of first time developers a lot of time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/406)

<!-- Reviewable:end -->

<!---
@huboard:{"order":198.1188297039603,"milestone_order":406,"custom_state":""}
-->
