### PR TITLE
Update client package.json - fixes #420

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,8 @@
     "core-js": "^2.1.0",
     "engine.io-client": "^1.6.9",
     "engine.io-parser": "socketio/engine.io-parser#748144b50a1d10e8c7c9b8100f2e21f8ac424c7a",
+    "exports-loader": "^0.6.3",
+    "imports-loader": "^0.6.5",
     "isomorphic-fetch": "^2.2.1",
     "rxjs": "^5.0.0-beta.6",
     "snake-case": "^1.1.2"
@@ -39,8 +41,6 @@
     "copy-webpack-plugin": "^1.1.1",
     "cross-env": "^1.0.7",
     "eslint": "2.2.x",
-    "exports-loader": "^0.6.3",
-    "imports-loader": "^0.6.5",
     "istanbul": "^0.4.2",
     "lodash": "^4.6.1",
     "mocha": "2.3.4",


### PR DESCRIPTION
move imports/exports-loader to dependencies to fix issues when using horizon as a dependency with a custom webpack setup

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/437)

<!-- Reviewable:end -->
