### PR TITLE
Remove auth_redirect from yes_no_options

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -263,8 +263,7 @@ const yes_no_options = [ 'debug',
                          'auto_create_index',
                          'auto_create_collection',
                          'allow_unauthenticated',
-                         'allow_anonymous',
-                         'auth_redirect' ];
+                         'allow_anonymous' ];
 
 const parse_connect = (connect, config) => {
   const host_port = connect.split(':');


### PR DESCRIPTION
auth_redirect in config.toml takes a string argument specifying the URL to redirect the user to for auth. It was incorrectly being enforced as a boolean so it could not be configured in the config file.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/439)

<!-- Reviewable:end -->
