### PR TITLE
CLI: move bind all check to after configs are merged

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -401,10 +401,6 @@ const read_config_from_flags = (parsed) => {
   }
   if (parsed.bind !== null && parsed.bind !== undefined) {
     config.bind = parsed.bind;
-
-    if (config.bind.indexOf('all') !== -1) {
-      config.bind = [ '0.0.0.0' ];
-    }
   }
 
   if (parsed.token_secret !== null && parsed.token_secret !== undefined) {
@@ -465,6 +461,10 @@ const processConfig = (parsed) => {
 
   if (config.project_name === null) {
     config.project_name = path.basename(path.resolve(config.project_path));
+  }
+
+  if (config.bind.indexOf('all') !== -1) {
+    config.bind = [ '0.0.0.0' ];
   }
 
   return config;


### PR DESCRIPTION
Before, `serve.js` would not handle `bind=all` in config files or environment variables.  Now that check is only performed after all config parameter sources have been merged together.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/452)

<!-- Reviewable:end -->
