### PR TITLE
Fix changefeed handling and make-token

### DIFF
--- a/cli/src/make-token.js
+++ b/cli/src/make-token.js
@@ -105,7 +105,7 @@ const runCommand = (options, done) => {
       throw new Error('User does not exist.');
     }
 
-    const token = jwt.sign({ user: res.id, provider: null },
+    const token = jwt.sign({ id: res.id, provider: null },
                            new Buffer(options.token_secret, 'base64'),
                            { expiresIn: '1d', algorithm: 'HS512' });
     console.log(`${token}`);

--- a/server/src/endpoint/query.js
+++ b/server/src/endpoint/query.js
@@ -94,7 +94,7 @@ const run = (raw_request, context, ruleset, metadata, send, done) => {
       return cursor.eachAsync((item) => {
         if (!ruleset.validate(context, item)) {
           done(new Error('Operation not permitted.'));
-          cursor.close();
+          cursor.close().catch(() => { });
         } else {
           send({ data: [ item ] });
         }
@@ -117,7 +117,7 @@ const run = (raw_request, context, ruleset, metadata, send, done) => {
 
   return () => {
     if (cursor) {
-      cursor.close();
+      cursor.close().catch(() => { });
     }
   };
 };

--- a/server/src/endpoint/subscribe.js
+++ b/server/src/endpoint/subscribe.js
@@ -33,7 +33,7 @@ const run = (raw_request, context, ruleset, metadata, send, done) => {
 
   return () => {
     if (feed) {
-      feed.close();
+      feed.close().catch(() => { });
     }
   };
 };


### PR DESCRIPTION
Three major changes:
- `make-token` was generating tokens with the old format, using 'user' instead of 'id'
- changefeeds from `query`, `subscribe`, and `get_user_feed` were not being `catch`ed when closed
- the `user_feed` in `Client` was not being handled properly

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/473)

<!-- Reviewable:end -->
