### PR TITLE
Set process.title properly

### DIFF
--- a/cli/src/main.js
+++ b/cli/src/main.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
+// To support `pidof horizon`, by default it shows in `pidof node`
+process.title = 'horizon'
+
 const argparse = require('argparse');
 const chalk = require('chalk');
 const initCommand = require('./init');


### PR DESCRIPTION
To support `pidof horizon`, by default it shows in `pidof node`
This will save us from accidental kill when we are trying to kill another node app instead of horizon by `killall node`

PS. I've signed the CLA

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/480)

<!-- Reviewable:end -->
