### PR TITLE
set rxjs dependency to fixed v 5.0.0-beta.7 until rxjs5 is out of beta

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "exports-loader": "^0.6.3",
     "imports-loader": "^0.6.5",
     "isomorphic-fetch": "^2.2.1",
-    "rxjs": "^5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.7",
     "snake-case": "^1.1.2"
   },
   "engines": {


### PR DESCRIPTION
fixes https://github.com/rethinkdb/horizon/issues/484

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/488)

<!-- Reviewable:end -->
