### PR TITLE
Return of the --open flag 

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -31,6 +31,7 @@
     "jsonwebtoken": "^5.5.4",
     "mime-types": "^2.0.4",
     "rethinkdb": "^2.1.1",
+    "open": "0.0.5",
     "toml": "^2.3.0"
   },
   "devDependencies": {

--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -580,23 +580,18 @@ const runCommand = (opts, done) => {
     // Automatically open up index.html in the `dist` directory only if
     //  `--open` flag specified and an index.html exists in the directory.
     if (opts.open && opts.serve_static) {
-      // Check if index.html exists and readable in serve static_static directory
-      fs.access(`${opts.serve_static}/index.html`, fs.R_OK | fs.F_OK, (err) => {
-        if (err) {
-          console.log('Could not find index.html, will not auto open');
-        } else {
-          console.log('Attempting open of index.html in default browser');
-          // Determine scheme from options
-          const scheme = opts.secure ? 'https://' : 'http://';
-          // Open up index.html in default browser
-          try {
-            open(`${scheme}${opts.bind}:${opts.port}/index.html`);
-          } catch (open_err) {
-            console.log(`Error occurred while trying to open ${opts.serve_static}/index.html`);
-            console.log(open_err);
-          }
-        }
-      });
+      try {
+        // Check if index.html exists and readable in serve static_static directory
+        fs.accessSync(`${opts.serve_static}/index.html`, fs.R_OK | fs.F_OK);
+        // Determine scheme from options
+        const scheme = opts.secure ? 'https://' : 'http://';
+        // Open up index.html in default browser
+        console.log('Attempting open of index.html in default browser');
+        open(`${scheme}${opts.bind}:${opts.port}/index.html`);
+      } catch (open_err) {
+        console.log(chalk.red(`Error occurred while trying to open ${opts.serve_static}/index.html`));
+        console.log(open_err);
+      }
     }
   }).catch(done);
 };

--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -578,7 +578,7 @@ const runCommand = (opts, done) => {
     }
   }).then(() => {
     // Automatically open up index.html in the `dist` directory only if
-    //  in dev mode and an index.html exists in the directory.
+    //  `--open` flag specified and an index.html exists in the directory.
     if (opts.open && opts.serve_static) {
       // Check if index.html exists and readable in serve static_static directory
       fs.access(`${opts.serve_static}/index.html`, fs.R_OK | fs.F_OK, (err) => {


### PR DESCRIPTION
Re-added this since serve.js had deviated a bit from previous. Now works only with `--open` flag as desired from comments before. Only wish would be that in the case of multiple `--open`ings that it would just refresh the already opened window and tab.

https://stackoverflow.com/questions/8454510/open-url-in-same-window-and-in-same-tab

closes #223

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/504)

<!-- Reviewable:end -->
