### PR TITLE
POC for custom auth

### DIFF
--- a/server/src/client.js
+++ b/server/src/client.js
@@ -24,10 +24,19 @@ class Client {
 
     this._socket.on('error', (error) =>
       this.handle_websocket_error(error));
-
+    
+    // not pretty, hardcoded modulename
+    this._custom = this._server._auth_modules.get('customModule')
+        
     // The first message should always be the handshake
-    this._socket.once('message', (data) =>
-      this.error_wrap_socket(() => this.handle_handshake(data)));
+    // if custom_auth is enabled pass the handshake to that instead
+    if(this._server._custom_auth){
+      this._socket.once('message', (data) =>
+        this.error_wrap_socket(() => this._custom(this, data, this._auth._jwt)));
+    }else{
+      this._socket.once('message', (data) =>
+        this.error_wrap_socket(() => this.handle_handshake(data)));    
+    }
 
     if (!this._metadata.is_ready()) {
       this.close({ error: 'No connection to the database.' });
@@ -62,6 +71,22 @@ class Client {
   }
 
   parse_request(data, schema) {
+
+    // not pretty right now, just to allow accessing this from the server in a simple way
+    switch (schema){
+      case 'request':
+        console.log('request')
+        schema = schemas.request
+        break;
+      case 'handshake':
+        console.log('handshake')
+        schema = schemas.handshake
+        break;
+      default:
+        break;
+    }
+    
+     
     let request;
     try {
       request = JSON.parse(data);

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -30,18 +30,34 @@ class Client {
     // The first message should always be the handshake
     // if custom_auth is enabled pass the handshake to those instead
     if(this._server._custom_auth){
+      
+      this._custom.forEach((x) => {
+        x(this)
+      })
+      /*
       this._socket.once('message', (data) => {
         this.error_wrap_socket(() => {
           this._custom.forEach((x) => {
+            console.log('message passed to custom ')
             x(this, data, this._auth._jwt)
           })
         })
         
+        
+        
       })
+      
+      */
         
     }else{
-      this._socket.once('message', (data) =>
-        this.error_wrap_socket(() => this.handle_handshake(data)));    
+      this._socket.once('message', (data) => {
+        this.error_wrap_socket(() => {
+          console.log('the initial message', data)
+          this.handle_handshake(data)
+        })
+      })
+        
+          
     }
 
     if (!this._metadata.is_ready()) {
@@ -136,9 +152,14 @@ class Client {
         if (!responded) {
           responded = true;
           const info = { token: res.token, id: res.payload.id, provider: res.payload.provider };
-          this.send_response(request, info);
-          this._socket.on('message', (msg) =>
-            this.error_wrap_socket(() => this.handle_request(msg)));
+          //this.send_response(request, info);
+          this._socket.on('message', (msg) => {
+            this.error_wrap_socket(() => {
+              console.log('the second message')
+              this.handle_request(msg)
+            })
+          })
+
         }
       };
       this.user_info = res.payload;
@@ -150,9 +171,9 @@ class Client {
             if (!change.new_val) {
               throw new Error('User account has been deleted.');
             }
-            Object.assign(this.user_info, change.new_val);
-            this._requests.forEach((req) => req.evaluate_rules());
-            finish_handshake();
+            //Object.assign(this.user_info, change.new_val);
+            //this._requests.forEach((req) => req.evaluate_rules());
+            //finish_handshake();
           }).then(() => {
             throw new Error('User account feed has been lost.');
           });
@@ -176,6 +197,7 @@ class Client {
     if (raw_request === undefined) {
       return;
     } else if (raw_request.type === 'end_subscription') {
+      console.log('should end subscription')
       return this.remove_request(raw_request); // there is no response for end_subscription
     }
 

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -25,14 +25,20 @@ class Client {
     this._socket.on('error', (error) =>
       this.handle_websocket_error(error));
     
-    // not pretty, hardcoded modulename
-    this._custom = this._server._auth_modules.get('customModule')
+    this._custom = this._server._auth_modules;
         
     // The first message should always be the handshake
-    // if custom_auth is enabled pass the handshake to that instead
+    // if custom_auth is enabled pass the handshake to those instead
     if(this._server._custom_auth){
-      this._socket.once('message', (data) =>
-        this.error_wrap_socket(() => this._custom(this, data, this._auth._jwt)));
+      this._socket.once('message', (data) => {
+        this.error_wrap_socket(() => {
+          this._custom.forEach((x) => {
+            x(this, data, this._auth._jwt)
+          })
+        })
+        
+      })
+        
     }else{
       this._socket.once('message', (data) =>
         this.error_wrap_socket(() => this.handle_handshake(data)));    
@@ -75,11 +81,9 @@ class Client {
     // not pretty right now, just to allow accessing this from the server in a simple way
     switch (schema){
       case 'request':
-        console.log('request')
         schema = schemas.request
         break;
       case 'handshake':
-        console.log('handshake')
         schema = schemas.handshake
         break;
       default:

--- a/server/src/schema/server_options.js
+++ b/server/src/schema/server_options.js
@@ -6,6 +6,8 @@ const server = Joi.object({
   project_name: Joi.string().default('horizon'),
   rdb_host: Joi.string().hostname().default('localhost'),
   rdb_port: Joi.number().greater(0).less(65536).default(28015),
+  
+  custom_auth: Joi.boolean().default(false),
 
   auto_create_collection: Joi.boolean().default(false),
   auto_create_index: Joi.boolean().default(false),

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -71,6 +71,8 @@ class Server {
     this._name = opts.project_name;
     this._permissions_enabled = opts.permissions;
     this._auth_methods = { };
+    this._custom_auth = opts.custom_auth;
+    this._auth_modules = new Map();
     this._request_handlers = new Map();
     this._http_handlers = new Map();
     this._ws_servers = new Set();
@@ -152,6 +154,10 @@ class Server {
     } else {
       http_servers.forEach((s) => { add_websocket(s); add_http_listener(s); });
     }
+  }
+  
+  registerAuthModule(module_name, cbs){
+    this._auth_modules.set(module_name, cbs)
   }
 
   add_request_handler(request_name, endpoint) {


### PR DESCRIPTION
I just tried this out mainly because I need it myself, and hopefully its in some way usable! :)

The code could probably be done a little better, and I'm not sure it would make any sense allowing multiple auth modules, but it should work.
I added an option to the server so that this could be enabled or disabled, disabled wouldn't change anything from the default setup.
Right now it allows you to combine your own parts with parts from the server so I think it does it's purpose.

a small examples would be

```
server.registerAuthModule('customModule', (hz, handshake, jwt) => {

    var parsed = hz.parse_request(handshake, 'handshake') // <-- the only reason for the switch part which isnt an optimal solution

    // verify a token
    jwt.verify(parsed.token).then((res) => {

    })

  // pass a response back
  function finish_custom_handshake(data){
    var inf = { 
      id: 'undefined',
      provider: 'custom',
      token: token.token
    }
    hz.send_response(data, inf);
    hz._socket.on('message', (msg) => {
      hz.error_wrap_socket(() => {
        hz.handle_request(msg)
      })
    })
  }

  finish_custom_handshake(parsed)


})

```

I think that you understand what could be done in here.

I thought this would be good because it really doesn't change any existing logic and that it would be good the get this added now so that it follows in future relases.

Would be glad to hear what you think.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/506)

<!-- Reviewable:end -->
