### PR TITLE
Make it more obvious that it works

### DIFF
--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -25,7 +25,7 @@ const makeIndexHTML = (projectName) => `\
     </script>
   </head>
   <body>
-   <marquee><h1></h1></marquee>
+   <marquee direction="left"><h1></h1></marquee>
   </body>
 </html>
 `;


### PR DESCRIPTION
As I was trying out horizon for the first time my server returned a blank screen. Or so I thought because the default `<marquee>` animates in so slowly from the right. Of course, had I waited two seconds longer on my 27" screen I would have seen the 'It works!' text…

So, this proposed change reverses the direction in order for the text to appear immediately to the left.

I realize this is a minor issue, if it all, but it took me a minute to figure out.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/524)

<!-- Reviewable:end -->
