### PR TITLE
revert engine.io back to ws

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,13 +16,12 @@
   "dependencies": {
     "babel-runtime": "^6.6.1",
     "core-js": "^2.1.0",
-    "engine.io-client": "^1.6.9",
-    "engine.io-parser": "socketio/engine.io-parser#748144b50a1d10e8c7c9b8100f2e21f8ac424c7a",
     "exports-loader": "^0.6.3",
     "imports-loader": "^0.6.5",
     "isomorphic-fetch": "^2.2.1",
     "rxjs": "5.0.0-beta.7",
-    "snake-case": "^1.1.2"
+    "snake-case": "^1.1.2",
+    "ws": "^1.1.0"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/client/test/test.js
+++ b/client/test/test.js
@@ -23,6 +23,8 @@ if (BROWSER) {
   global.mocha.setup('bdd')
   global.mocha.timeout(10000)
 } else {
+  global.WebSocket = require('ws')
+
   if (__dirname.split(path.sep).pop(-1) === 'test') {
     global.Horizon = require('../lib/index.js')
   } else {

--- a/client/webpack.horizon.config.js
+++ b/client/webpack.horizon.config.js
@@ -40,9 +40,9 @@ module.exports = function(buildTarget) {
     },
     externals: [
       function(context, request, callback) {
-      // Selected modules are not packaged into horizon.js. Webpack
-      // allows them to be required natively at runtime, either from
-      // filesystem (node) or window global.
+        // Selected modules are not packaged into horizon.js. Webpack
+        // allows them to be required natively at runtime, either from
+        // filesystem (node) or window global.
         if (!POLYFILL && /^rxjs\/?/.test(request)) {
           callback(null, {
           // If loaded via script tag, has to be at window.Rx when

--- a/server/package.json
+++ b/server/package.json
@@ -25,17 +25,16 @@
     "@horizon/client": "1.0.3",
     "bluebird": "^3.4.0",
     "cookie": "^0.2.3",
-    "engine.io": "^1.6.9",
     "joi": "^8.0.4",
     "jsonwebtoken": "^5.5.4",
     "mime-types": "^2.0.4",
     "oauth": "^0.9.14",
     "pem": "^1.8.1",
     "rethinkdb": "^2.1.1",
-    "winston": "^2.1.0"
+    "winston": "^2.1.0",
+    "ws": "^1.1.0"
   },
   "devDependencies": {
-    "engine.io-client": "^1.6.9",
     "eslint": "^2.3.0",
     "istanbul": "^0.4.3",
     "mocha": "^2.3.3",

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -5,6 +5,7 @@ const schemas = require('./schema/horizon_protocol');
 const Request = require('./request').Request;
 
 const Joi = require('joi');
+const websocket = require('ws');
 
 class Client {
   constructor(socket, server) {
@@ -171,7 +172,7 @@ class Client {
   }
 
   is_open() {
-    return this._socket.readyState === 'open';
+    return this._socket.readyState === websocket.OPEN;
   }
 
   close(info) {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -27,7 +27,7 @@ const fs = require('fs');
 const Joi = require('joi');
 const path = require('path');
 const url = require('url');
-const websocket = require('engine.io');
+const websocket = require('ws');
 
 const protocol_name = 'rethinkdb-horizon-v0';
 
@@ -87,23 +87,20 @@ class Server {
     const verify_client = (info, cb) => {
       // Reject connections if we aren't synced with the database
       if (!this._reql_conn.is_ready()) {
-        cb(503, false);
+        cb(false, 503, 'Connection to the database is down.');
       } else {
-        cb(false, true);
+        cb(true);
       }
     };
 
     const ws_options = { handleProtocols: accept_protocol,
-                         allowRequest: verify_client };
+                         allowRequest: verify_client,
+                         path: this._path };
 
     const add_websocket = (server) => {
-      const ws_server = websocket(Object.assign({}, ws_options))
+      const ws_server = new websocket.Server(Object.assign({ server }, ws_options))
       .on('error', (error) => logger.error(`Websocket server error: ${error}`))
       .on('connection', (socket) => new Client(socket, this));
-
-      ws_server.attach(server, {
-        path: this._path,
-      });
 
       this._ws_servers.add(ws_server);
     };

--- a/server/test/protocol_tests.js
+++ b/server/test/protocol_tests.js
@@ -11,8 +11,9 @@ const all_tests = (collection) => {
     const conn = utils.horizon_conn();
     conn.removeAllListeners('error');
     conn.send('foobar');
-    conn.once('close', (reason) => {
-      assert.strictEqual(reason, 'transport close');
+    conn.once('close', (code, reason) => {
+      assert.strictEqual(code, 1002);
+      assert(/^Invalid JSON/.test(reason));
       done();
     });
   });
@@ -21,8 +22,9 @@ const all_tests = (collection) => {
     const conn = utils.horizon_conn();
     conn.removeAllListeners('error');
     conn.send('{ }');
-    conn.once('close', (reason) => {
-      assert.strictEqual(reason, 'transport close');
+    conn.once('close', (code, reason) => {
+      assert.strictEqual(code, 1002);
+      assert(/^Protocol error: ValidationError/.test(reason));
       done();
     });
   });


### PR DESCRIPTION
Engine.io is causing problems for people in a number of cases - #525, #413, #379.  This branch reverts it back to `ws`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/526)

<!-- Reviewable:end -->
