### PR TITLE
Fix index and table desyncing issues

### DIFF
--- a/cli/src/set-schema.js
+++ b/cli/src/set-schema.js
@@ -5,9 +5,9 @@ const parse_yes_no_option = require('./utils/parse_yes_no_option');
 const start_rdb_server = require('./utils/start_rdb_server');
 const serve = require('./serve');
 const logger = require('@horizon/server').logger;
-const create_collection_reql = require('@horizon/server/src/metadata').create_collection_reql;
-const initialize_metadata_reql = require('@horizon/server/src/metadata').initialize_metadata_reql;
-const name_to_fields = require('@horizon/server/src/index').Index.name_to_fields;
+const create_collection_reql = require('@horizon/server/src/metadata/metadata').create_collection_reql;
+const initialize_metadata_reql = require('@horizon/server/src/metadata/metadata').initialize_metadata_reql;
+const name_to_fields = require('@horizon/server/src/metadata/index').Index.name_to_fields;
 
 const fs = require('fs');
 const Joi = require('joi');

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -135,7 +135,7 @@ class Client {
     }).catch((err) => {
       if (!responded) {
         responded = true;
-        this.close({ request_id: request.request_id, error: `${err}`, error_code: 0 })
+        this.close({ request_id: request.request_id, error: `${err}`, error_code: 0 });
       }
     });
   }

--- a/server/src/metadata/collection.js
+++ b/server/src/metadata/collection.js
@@ -38,7 +38,6 @@ class Collection {
   }
 
   set_table(table) {
-    console.log(`Collection ${this.name} assigned a table - propagating ${this._waiters.length} waiters.`);
     table.collection = this;
     this._table = table;
     this._waiters.forEach((done) => this._table.on_ready(done));

--- a/server/src/metadata/collection.js
+++ b/server/src/metadata/collection.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const error = require('../error');
+
+const r = require('rethinkdb');
+
+class Collection {
+  constructor(data, db) {
+    this.name = data.id;
+    this._waiters = [ ];
+    this.changed(data, db);
+  }
+
+  close() {
+    if (this._table) {
+      this._table.close();
+      this._table = null;
+    } else {
+      this._waiters.forEach((w) => w(new Error('collection deleted')));
+      this._waiters = [ ];
+    }
+  }
+
+  changed(data, db) {
+    error.check(this.name === data.id, 'Collections cannot be renamed.');
+
+    this.table = r.db(db).table(data.table); // This is the ReQL `Table` object
+    this._table_name = data.table;
+    this._table = null; // This is the Horizon `Table` object
+  }
+
+  on_ready(done) {
+    if (this._table) {
+      this._table.on_ready(done);
+    } else {
+      this._waiters.push(done);
+    }
+  }
+
+  set_table(table) {
+    console.log(`Collection ${this.name} assigned a table - propagating ${this._waiters.length} waiters.`);
+    table.collection = this;
+    this._table = table;
+    this._waiters.forEach((done) => this._table.on_ready(done));
+    this._waiters = [ ];
+  }
+
+  create_index() {
+    if (!this._table) {
+      throw new error.CollectionNotReady(this);
+    }
+    return this._table.create_index.apply(this._table, arguments);
+  }
+
+  get_matching_index() {
+    if (!this._table) {
+      throw new error.CollectionNotReady(this);
+    }
+    return this._table.get_matching_index.apply(this._table, arguments);
+  }
+}
+
+module.exports = { Collection };

--- a/server/src/metadata/metadata.js
+++ b/server/src/metadata/metadata.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const error = require('./error');
-const logger = require('./logger');
-const Group = require('./permissions/group').Group;
+const error = require('../error');
+const logger = require('../logger');
+const Group = require('../permissions/group').Group;
 const Collection = require('./collection').Collection;
-const version_field = require('./endpoint/writes').version_field;
+const Table = require('./table').Table;
+const version_field = require('../endpoint/writes').version_field;
 
 const r = require('rethinkdb');
 
@@ -57,6 +58,7 @@ class Metadata {
     this._auto_create_index = auto_create_index;
     this._closed = false;
     this._ready = false;
+    this._tables = new Map();
     this._collections = new Map();
     this._groups = new Map();
     this._collection_feed = null;
@@ -80,6 +82,7 @@ class Metadata {
             return new Promise((resolve, reject) => {
               this._group_feed = res;
               this._group_feed.eachAsync((change) => {
+                logger.debug(`groups change: ${JSON.stringify(change)}`);
                 if (change.type === 'state') {
                   if (change.state === 'ready') {
                     logger.info('Groups metadata synced.');
@@ -116,6 +119,7 @@ class Metadata {
             return new Promise((resolve, reject) => {
               this._collection_feed = res;
               this._collection_feed.eachAsync((change) => {
+                logger.debug(`collections change: ${JSON.stringify(change)}`);
                 if (change.type === 'state') {
                   if (change.state === 'ready') {
                     logger.info('Collections metadata synced.');
@@ -126,14 +130,28 @@ class Metadata {
                            change.type === 'change') {
                   // Ignore special collections
                   if (change.new_val.id !== 'users') {
-                    const collection = new Collection(change.new_val, this._db, this._conn);
-                    this._collections.set(collection.name, collection);
+                    let collection = this._collections.get(change.new_val.id);
+                    if (!collection) {
+                      collection = new Collection(change.new_val, this._db);
+                      this._collections.set(change.new_val.id, collection);
+                    } else {
+                      collection.changed(change.new_val, this._db);
+                    }
+
+                    // Check if we already have a table object for this collection
+                    // TODO: timer-supervise this state - if we don't have a table after x seconds, delete the collection row
+                    const table = this._tables.get(collection._table_name);
+                    if (table) {
+                      collection.set_table(table);
+                    }
                   }
                 } else if (change.type === 'uninitial' ||
                            change.type === 'remove') {
                   // Ignore special collections
                   if (change.old_val.id !== 'users') {
+                    const collection = this._collections.get(change.old_val.id);
                     this._collections.delete(change.old_val.id);
+                    collection.close();
                   }
                 }
               }).catch(reject);
@@ -156,6 +174,7 @@ class Metadata {
             return new Promise((resolve, reject) => {
               this._index_feed = res;
               this._index_feed.eachAsync((change) => {
+                logger.debug(`tables/indexes change: ${JSON.stringify(change)}`);
                 if (change.type === 'state') {
                   if (change.state === 'ready') {
                     logger.info('Index metadata synced.');
@@ -164,12 +183,24 @@ class Metadata {
                 } else if (change.type === 'initial' ||
                            change.type === 'add' ||
                            change.type === 'change') {
-                  const table = change.new_val.name;
+                  const table_name = change.new_val.name;
+                  let table = this._tables.get(table_name);
+                  if (!table) {
+                    table = new Table(table_name, this._db, this._conn);
+                    this._tables.set(table_name, table);
+                  }
+                  table.update_indexes(change.new_val.indexes, this._conn);
+
                   this._collections.forEach((c) => {
-                    if (c.table === table) {
-                      c.update_indexes(change.new_val.indexes, this._conn);
+                    if (c._table_name === table_name) {
+                      c.set_table(table);
                     }
                   });
+                } else if (change.type === 'uninitial' ||
+                           change.type === 'remove') {
+                  const table = this._tables.get(change.old_val.name);
+                  this._tables.delete(change.old_val.name);
+                  table.close();
                 }
               }).catch(reject);
             });
@@ -211,7 +242,7 @@ class Metadata {
               {
                 id: 'admin',
                 groups: [ 'admin' ],
-                [version_field]: 0
+                [version_field]: 0,
               },
               old_row),
             { returnChanges: 'always' })('changes')(0)
@@ -237,8 +268,13 @@ class Metadata {
     }).then(() => {
       logger.debug('redirecting users table');
       // Redirect the 'users' table to the one in the internal db
-      this._collections.set('users', new Collection({ id: 'users', table: 'users' },
-                                                    this._internal_db, this._conn));
+      const users_table = new Table('users', this._internal_db, this._conn);
+      const users_collection = new Collection({ id: 'users', table: 'users' }, this._internal_db);
+
+      users_collection.set_table(users_table);
+
+      this._tables.set('users', users_table);
+      this._collections.set('users', users_collection);
     }).then(() => {
       logger.debug('metadata sync complete');
       this._ready = true;
@@ -310,14 +346,26 @@ class Metadata {
     error.check(this._collections.get(name) === undefined,
                 `Collection "${name}" already exists.`);
 
+    const collection = new Collection({ id: name, table: null }, this._db);
+    this._collections.set(name, collection);
+
     create_collection_reql(r, this._internal_db, this._db, name)
       .run(this._conn)
       .then((res) => {
-        error.check(!res.error, `Collection creation failed (dev mode): "${name}", ${res.error}`);
+        if (res.error) {
+          error.fail(`Collection creation failed (dev mode): "${name}", ${res.error}`);
+        }
         logger.warn(`Collection created (dev mode): "${name}"`);
-        this._collections.set(name, new Collection(res.new_val, this._db, this._conn));
-        done();
-      }).catch(done);
+        collection.on_ready(done);
+      }).catch((err) => {
+        // If an error occurred we should clean up this proto-collection - but only if
+        // it hasn't changed yet - e.g. it was created by another instance at the same time.
+        if (collection._table_name === null) {
+          collection.close();
+          this._collections.delete(name);
+        }
+        done(err);
+      });
   }
 
   get_user_feed(id) {

--- a/server/src/metadata/metadata.js
+++ b/server/src/metadata/metadata.js
@@ -172,7 +172,6 @@ class Metadata {
             return new Promise((resolve, reject) => {
               this._index_feed = res;
               this._index_feed.eachAsync((change) => {
-                logger.debug(`Got indexes change: ${JSON.stringify(change)}`);
                 if (change.type === 'state') {
                   if (change.state === 'ready') {
                     logger.info('Index metadata synced.');
@@ -358,9 +357,7 @@ class Metadata {
     create_collection_reql(r, this._internal_db, this._db, name)
       .run(this._conn)
       .then((res) => {
-        if (res.error) {
-          error.fail(`Collection creation failed (dev mode): "${name}", ${res.error}`);
-        }
+        error.check(!res.error, `Collection creation failed (dev mode): "${name}", ${res.error}`);
         logger.warn(`Collection created (dev mode): "${name}"`);
         collection.on_ready(done);
       }).catch((err) => {

--- a/server/src/reql_connection.js
+++ b/server/src/reql_connection.js
@@ -2,7 +2,7 @@
 
 const check = require('./error').check;
 const logger = require('./logger');
-const Metadata = require('./metadata').Metadata;
+const Metadata = require('./metadata/metadata').Metadata;
 const r = require('rethinkdb');
 const utils = require('./utils');
 


### PR DESCRIPTION
The problem from issue #533 (and some other problems I encountered while debugging this) was that our internal representation of which tables and indexes existed did not align with the actual queries we were running.

Specifically, in this commit, a `Collection` has been split up into a `Collection` (representing the row in the `horizon_internal.collections` table), and a `Table` (representing the underlying table in the `horizon` database).  At the same time, I added some more error handling to deal with properly passing errors to queries when the table or index is deleted while some are waiting on them to be ready.

In addition, I moved all the metadata files (`metadata.js`, `collection.js`, and `index.js`) into the `metadata` subdirectory.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/558)

<!-- Reviewable:end -->
