### PR TITLE
Fix lazy currentUser

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -97,6 +97,7 @@ function Horizon({
   horizon.utensils = {
     sendRequest,
     tokenStorage,
+    handshake: socket.handshake,
   }
   Object.freeze(horizon.utensils)
 

--- a/client/test/auth.js
+++ b/client/test/auth.js
@@ -8,17 +8,21 @@ const authSuite = global.authSuite = (getHorizon) => () => {
     horizon = getHorizon()
   })
   it('gets an empty object when unauthenticated', done => {
-    horizon.currentUser().fetch().subscribe(
-      user => {
+    horizon.currentUser().fetch().subscribe({
+      next(user) {
         assert.isObject(user)
         assert.deepEqual([], Object.keys(user))
       },
-      err => done(err),
-      complete => done()
-    )
+      error(err) { done(err) },
+      complete() { done() },
+    })
   })
   it('gets a normal user object when anonymous', done => {
-    const myHorizon = Horizon({ secure: false, lazyWrites: true, authType: 'anonymous' })
+    const myHorizon = Horizon({
+      secure: false,
+      lazyWrites: true,
+      authType: 'anonymous'
+    })
     Horizon.clearAuthTokens()
     myHorizon.connect()
     myHorizon.currentUser().fetch().subscribe({


### PR DESCRIPTION
Fixes #567 

The issue was that subscribing to the handshake doesn't force a connection, it only sets a callback whenever the handshake happens to be completed. Now, when subscribing `currentUser().fetch()` or `currentUser.watch()` an actual connection will be made.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/586)

<!-- Reviewable:end -->
