### PR TITLE
Change version check to not require a non-proxy rethinkdb node

### DIFF
--- a/server/src/reql_connection.js
+++ b/server/src/reql_connection.js
@@ -70,14 +70,12 @@ class ReqlConnection {
          logger.error(`Error on connection to RethinkDB: ${err}.`);
          retry();
        });
-       return conn.server().then((serv) =>
-         r.db('rethinkdb').table('server_status')
-          .get(serv.id)('process')('version')
-          .run(conn)
-          .then((res) => {
-            utils.rethinkdb_version_check(res);
-            return conn;
-          }));
+       return r.db('rethinkdb').table('server_status').nth(0)('process')('version')
+               .run(conn)
+               .then((res) => {
+                 utils.rethinkdb_version_check(res);
+                 return conn;
+               });
      }).then((conn) => {
        this._connection = conn;
        this._metadata = new Metadata(this._project_name,


### PR DESCRIPTION
Fixes issue #564.  The version check doesn't need to be so strict at the moment, because RethinkDB does not allow clusters to be made up with wildly varied binary versions.  If in the future we depend on behavior that could exist in some (but not other) nodes in a cluster, we can make a more complicated solution here.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/597)

<!-- Reviewable:end -->
