### PR TITLE
Fix launching the CLI without access_control_allow_origin

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -564,6 +564,11 @@ const runCommand = (opts, done) => {
     logger.level = 'warn';
   }
 
+  if (!opts.secure && opts.auth && Array.from(Object.keys(opts.auth)).length > 0) {
+    logger.warn('Authentication requires that the server be accessible via HTTPS. ' +
+                'Either specify "secure=true" or use a reverse proxy.');
+  }
+
   change_to_project_dir(opts.project_path);
 
   let http_servers, hz_instance;

--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -376,6 +376,7 @@ const read_config_from_flags = (parsed) => {
 
   // Dev mode
   if (parsed.dev) {
+    config.access_control_allow_origin = '*';
     config.allow_unauthenticated = true;
     config.allow_anonymous = true;
     config.secure = false;

--- a/server/src/schema/server_options.js
+++ b/server/src/schema/server_options.js
@@ -16,7 +16,7 @@ const server = Joi.object({
 
   auth: Joi.object().default({ }),
   
-  access_control_allow_origin: Joi.string().default('')
+  access_control_allow_origin: Joi.string().allow('').default('')
 }).unknown(false);
 
 const auth = Joi.object({


### PR DESCRIPTION
The default behavior in the CLI was broken.  Also added a warning message fixing #211.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/604)

<!-- Reviewable:end -->
