### PR TITLE
Use rxjs 5 WebSocketSubject

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "babel-runtime": "^6.6.1",
     "core-js": "^2.1.0",
     "es6-promise": "^3.2.1",
-    "rxjs": "5.0.0-beta.7",
+    "rxjs": ">=5.0.0-beta.10",
     "snake-case": "^1.1.2",
     "ws": "^1.1.0"
   },

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,4 +1,3 @@
-import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/from'
 import 'rxjs/add/operator/catch'
@@ -6,13 +5,12 @@ import 'rxjs/add/operator/concatMap'
 import 'rxjs/add/operator/map'
 import 'rxjs/add/operator/filter'
 
-// Extra operators not used, but useful to Horizon end-users
-import 'rxjs/add/operator/defaultIfEmpty'
+import * as Rx from 'rxjs'
+import { Collection, UserDataTerm } from './ast'
+import { HorizonSocket } from './socket'
+import { log, logError, enableLogging } from './logging'
+import { authEndpoint, TokenStorage, clearAuthTokens } from './auth'
 
-const { Collection, UserDataTerm } = require('./ast.js')
-const HorizonSocket = require('./socket.js')
-const { log, logError, enableLogging } = require('./logging.js')
-const { authEndpoint, TokenStorage, clearAuthTokens } = require('./auth')
 
 const defaultHost = typeof window !== 'undefined' && window.location &&
         `${window.location.host}` || 'localhost:8181'
@@ -25,6 +23,8 @@ function Horizon({
   path = 'horizon',
   lazyWrites = false,
   authType = 'unauthenticated',
+  keepalive = 60,
+  WebSocketCtor = WebSocket,
 } = {}) {
   // If we're in a redirection from OAuth, store the auth token for
   // this user in localStorage.
@@ -32,8 +32,13 @@ function Horizon({
   const tokenStorage = new TokenStorage({ authType, path })
   tokenStorage.setAuthFromQueryParams()
 
-  const socket = new HorizonSocket(
-    host, secure, path, ::tokenStorage.handshake)
+  const url = `ws${secure ? 's' : ''}:\/\/${host}\/${path}`
+  const socket = new HorizonSocket({
+    url,
+    handshakeMessage: tokenStorage.handshake(),
+    keepalive,
+    WebSocketCtor,
+  })
 
   // Store whatever token we get back from the server when we get a
   // handshake response
@@ -102,9 +107,9 @@ function Horizon({
   Object.freeze(horizon.utensils)
 
   horizon._authMethods = null
-  horizon._horizonPath = 'http' + ((secure) ? 's' : '') + '://' + host + '/' + path
+  horizon._horizonPath = `http${(secure) ? 's' : ''}://${host}/${path}`
   horizon.authEndpoint = authEndpoint
-  horizon.hasAuthToken = ::tokenStorage.hasAuthToken
+  horizon.hasAuthToken = tokenStorage.hasAuthToken.bind(tokenStorage)
 
   return horizon
 
@@ -114,19 +119,8 @@ function Horizon({
     // Both remove and removeAll use the type 'remove' in the protocol
     const normalizedType = type === 'removeAll' ? 'remove' : type
     return socket
-      .makeRequest({ type: normalizedType, options }) // send the raw request
-      .concatMap(resp => {
-        // unroll arrays being returned
-        if (resp.data) {
-          return Observable.from(resp.data)
-        } else {
-          // Still need to emit a document even if we have no new data
-          return Observable.from([ { state: resp.state, type: resp.type } ])
-        }
-      })
-      .catch(e => Observable.create(subscriber => {
-        subscriber.error(e)
-      })) // on error, strip error message
+      .hzRequest({ type: normalizedType, options }) // send the raw request
+      .takeWhile(resp => resp.state !== 'complete')
   }
 }
 

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -1,14 +1,16 @@
 import { AsyncSubject } from 'rxjs/AsyncSubject'
 import { BehaviorSubject } from 'rxjs/BehaviorSubject'
-import { Subject } from 'rxjs/Subject'
+import { WebSocketSubject } from 'rxjs/observable/dom/WebSocketSubject'
 import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/merge'
+import 'rxjs/add/observable/timer'
 import 'rxjs/add/operator/filter'
 import 'rxjs/add/operator/share'
+import 'rxjs/add/operator/ignoreElements'
+import 'rxjs/add/operator/concat'
+import 'rxjs/add/operator/takeWhile'
 
 import { serialize, deserialize } from './serialization.js'
-import { log } from './logging.js'
-import { WebSocket } from './shim.js'
 
 const PROTOCOL_VERSION = 'rethinkdb-horizon-v0'
 
@@ -31,231 +33,164 @@ class ProtocolError extends Error {
   }
 }
 
+
 // Wraps native websockets with a Subject, which is both an Subscriber
-// and an Observable (it is bi-directional after all!). This
-// implementation is adapted from Rx.DOM.fromWebSocket and
-// RxSocketSubject by Ben Lesh, but it also deals with some simple
-// protocol level things like serializing from/to JSON, routing
-// request_ids, looking at the `state` field to decide when an
-// observable is closed.
-class HorizonSocket extends Subject {
-  constructor(host, secure, path, handshaker) {
-    const hostString = `ws${secure ? 's' : ''}:\/\/${host}\/${path}`
-    const msgBuffer = []
-    let ws, handshakeDisp
-    // Handshake is an asyncsubject because we want it to always cache
-    // the last value it received, like a promise
-    const handshake = new AsyncSubject()
-    const statusSubject = new BehaviorSubject(STATUS_UNCONNECTED)
+// and an Observable (it is bi-directional after all!). This version
+// is based on the rxjs.observable.dom.WebSocketSubject implementation.
+export class HorizonSocket extends WebSocketSubject {
+  // Deserializes a message from a string. Overrides the version
+  // implemented in WebSocketSubject
+  resultSelector(e) {
+    return deserialize(JSON.parse(e.data))
+  }
 
-    const isOpen = () => Boolean(ws) && ws.readyState === WebSocket.OPEN
+  // We're overriding the next defined in AnonymousSubject so we
+  // always serialize the value. When this is called a message will be
+  // sent over the socket to the server.
+  next(value) {
+    const request = JSON.stringify(serialize(value))
+    super.next(request)
+  }
 
-    // Serializes to a string before sending
-    function wsSend(msg) {
-      const stringMsg = JSON.stringify(serialize(msg))
-      ws.send(stringMsg)
-    }
-
-    // This is the observable part of the Subject. It forwards events
-    // from the underlying websocket
-    const socketObservable = Observable.create(subscriber => {
-      ws = new WebSocket(hostString, PROTOCOL_VERSION);
-
-      ws.onerror = () => {
-        // If the websocket experiences the error, we forward it through
-        // to the observable. Unfortunately, the event we receive in
-        // this callback doesn't tell us much of anything, so there's no
-        // reason to forward it on and we just send a generic error.
-        statusSubject.next(STATUS_ERROR)
-        const errMsg = `Websocket ${hostString} experienced an error`
-        subscriber.error(new Error(errMsg))
-      }
-
-      ws.onopen = () => {
-        ws.onmessage = event => {
-          const deserialized = deserialize(JSON.parse(event.data))
-          log('Received', deserialized)
-          subscriber.next(deserialized)
-        }
-
-        ws.onclose = e => {
-          // This will happen if the socket is closed by the server If
-          // .close is called from the client (see closeSocket), this
-          // listener will be removed
-          statusSubject.next(STATUS_DISCONNECTED)
-          if (e.code !== 1000 || !e.wasClean) {
-            subscriber.error(
-              new Error(`Socket closed unexpectedly with code: ${e.code}`)
-            )
-          } else {
-            subscriber.complete()
+  constructor({
+    url,              // Full url to connect to
+    handshakeMessage, // function that returns handshake to emit
+    keepalive = 60,   // seconds between keepalive messages
+    WebSocketCtor = WebSocket,    // optionally provide a WebSocket constructor
+  } = {}) {
+    super({
+      url,
+      protocol: PROTOCOL_VERSION,
+      WebSocketCtor,
+      openObserver: {
+        next: () => this.sendHandshake(),
+      },
+      closeObserver: {
+        next: () => {
+          if (this._handshakeSub) {
+            this._handshakeSub.unsubscribe()
+            this._handshakeSub = null
           }
-        }
-
-        // Send the handshake
-        handshakeDisp = this.makeRequest(handshaker()).subscribe(
-          x => {
-            handshake.next(x)
-            handshake.complete()
-            statusSubject.next(STATUS_READY)
-          },
-          err => handshake.error(err),
-          () => handshake.complete()
-        )
-        // Send any messages that have been buffered
-        while (msgBuffer.length > 0) {
-          const msg = msgBuffer.shift()
-          log('Sending buffered:', msg)
-          wsSend(msg)
-        }
-      }
-      return () => {
-        if (handshakeDisp) {
-          handshakeDisp.unsubscribe()
-        }
-        // This is the "unsubscribe" method on the final Subject
-        closeSocket(1000, '')
-      }
-    }).share() // This makes it a "hot" observable, and refCounts it
-    // Note possible edge cases: the `share` operator is equivalent to
-    // .multicast(() => new Subject()).refCount() // RxJS 5
-    // .multicast(new Subject()).refCount() // RxJS 4
-
-    // This is the Subscriber part of the Subject. How we can send stuff
-    // over the websocket
-    const socketSubscriber = {
-      next(messageToSend) {
-        // When next is called on this subscriber
-        // Note: If we aren't ready, the message is silently dropped
-        if (isOpen()) {
-          log('Sending', messageToSend)
-          wsSend(messageToSend) // wsSend serializes to a string
-        } else {
-          log('Buffering', messageToSend)
-          msgBuffer.push(messageToSend)
-        }
+          this.status.next(STATUS_DISCONNECTED)
+        },
       },
-      error(error) {
-        // The subscriber is receiving an error. Better close the
-        // websocket with an error
-        if (!error.code) {
-          throw new Error('no code specified. Be sure to pass ' +
-                          '{ code: ###, reason: "" } to error()')
-        }
-        closeSocket(error.code, error.reason)
-      },
-      complete() {
-        // complete for the subscriber here is equivalent to "close
-        // this socket successfully (which is what code 1000 is)"
-        closeSocket(1000, '')
-      },
-    }
+    })
+    // Completes or errors based on handshake success. Buffers
+    // handshake response for later subscribers (like a Promise)
+    this.handshake = new AsyncSubject()
+    this._handshakeMsg = handshakeMessage
+    this._handshakeSub = null
 
-    function closeSocket(code, reason) {
-      statusSubject.next(STATUS_DISCONNECTED)
-      if (!code) {
-        ws.close() // successful close
-      } else {
-        ws.close(code, reason)
-      }
-      ws.onopen = null
-      ws.onclose = null
-      ws.onmessage = null
-      ws.onerror = null
-    }
+    this.keepalive = Observable
+      .timer(keepalive * 1000, keepalive * 1000)
+      .map(n => this._multiplex({ type: 'keepalive', n }))
+      .publish()
 
-    super(socketSubscriber, socketObservable)
-
-    // Subscriptions will be the observable containing all
-    // queries/writes/changefeed requests. Specifically, the documents
-    // that initiate them, each one with a different request_id
-    const subscriptions = new Subject()
-    // Unsubscriptions is similar, only it holds only requests to
-    // close a particular request_id on the server. Currently we only
-    // need these for changefeeds.
-    const unsubscriptions = new Subject()
-    const outgoing = Observable.merge(subscriptions, unsubscriptions)
-    // How many requests are outstanding
-    let activeRequests = 0
-    // Monotonically increasing counter for request_ids
-    let requestCounter = 0
-    // Unsubscriber for subscriptions/unsubscriptions
-    let subDisp = null
-    // Now that super has been called, we can add attributes to this
-    this.handshake = handshake
-    // Lets external users keep track of the current websocket status
-    // without causing it to connect
-    this.status = statusSubject
-
-    const incrementActive = () => {
-      if (++activeRequests === 1) {
-        // We subscribe the socket itself to the subscription and
-        // unsubscription requests. Since the socket is both an
-        // observable and an subscriber. Here it's acting as an subscriber,
-        // watching our requests.
-        subDisp = outgoing.subscribe(this)
-      }
-    }
-
-    // Decrement the number of active requests on the socket, and
-    // close the socket if we're the last request
-    const decrementActive = () => {
-      if (--activeRequests === 0) {
-        subDisp.unsubscribe()
-      }
-    }
-
-    // This is used externally to send requests to the server
-    this.makeRequest = rawRequest => Observable.create(reqSubscriber => {
-      // Get a new request id
-      const request_id = requestCounter++
-      // Add the request id to the request and the unsubscribe request
-      // if there is one
-      rawRequest.request_id = request_id
-      const unsubscribeRequest = { request_id, type: 'end_subscription' }
-      // First, increment activeRequests and decide if we need to
-      // connect to the socket
-      incrementActive()
-
-      // Now send the request to the server
-      subscriptions.next(rawRequest)
-
-      // Create an observable from the socket that filters by request_id
-      const unsubscribeFilter = this
-            .filter(x => x.request_id === request_id)
-            .subscribe(
-              resp => {
-                // Need to faithfully end the stream if there is an error
-                if (resp.error !== undefined) {
-                  reqSubscriber.error(
-                    new ProtocolError(resp.error, resp.error_code))
-                } else if (resp.data !== undefined ||
-                           resp.token !== undefined) {
-                  try {
-                    reqSubscriber.next(resp)
-                  } catch (e) { }
-                }
-                if (resp.state === 'synced') {
-                  // Create a little dummy object for sync notifications
-                  reqSubscriber.next({
-                    type: 'state',
-                    state: 'synced',
-                  })
-                } else if (resp.state === 'complete') {
-                  reqSubscriber.complete()
-                }
-              },
-              err => reqSubscriber.error(err),
-              () => reqSubscriber.complete()
-            )
-      return () => {
-        // Unsubscribe if necessary
-        unsubscriptions.next(unsubscribeRequest)
-        decrementActive()
-        unsubscribeFilter.unsubscribe()
-      }
+    // This is used to emit status changes that others can hook into.
+    this.status = new BehaviorSubject(STATUS_UNCONNECTED)
+    // Keep track of subscribers so we's can decide when to
+    // unsubscribe.
+    this.requestCounter = 0
+    // A map from request_ids to an object with metadata about the
+    // request. Eventually, this should allow re-sending requests when
+    // reconnecting.
+    this.activeRequests = new Map()
+    this._output.subscribe({
+      // This emits if the entire socket errors (usually due to
+      // failure to connect)
+      error: () => this.status.next(STATUS_ERROR),
     })
   }
-}
 
-module.exports = HorizonSocket
+  deactivateRequest(req) {
+    return () => {
+      this.activeRequests.delete(req.request_id)
+      return { request_id: req.request_id, type: 'end_subscription' }
+    }
+  }
+
+  activateRequest(req) {
+    return () => {
+      this.activeRequests.set(req.request_id, req)
+      return req
+    }
+  }
+
+  filterRequest(req) {
+    return resp => resp.request_id === req.request_id
+  }
+
+  getRequest(request) {
+    return Object.assign({ request_id: this.requestCounter++ }, request)
+  }
+
+  // This is a trimmed-down version of multiplex that only listens for
+  // the handshake requestId. It also starts the keepalive observable
+  // and cleans up after it when the handshake is cleaned up.
+  sendHandshake() {
+    if (this._handshakeSub) {
+      // If we already have a handshake subscription, just bail
+      return
+    }
+    this._handshakeSub = this.makeRequest(this._handshakeMsg)
+      .subscribe({
+        next: n => {
+          this.status.next(STATUS_READY)
+          this.handshake.next(n)
+          this.handshake.complete()
+        },
+        error: e => {
+          this.status.next(STATUS_ERROR)
+          this.handshake.error(e)
+        },
+      })
+
+    // Start the keepalive and make sure it's
+    // killed when the handshake is cleaned up
+    this._handshakeSub.add(this.keepalive.connect())
+  }
+
+  // Incorporates shared logic between the inital handshake request and
+  // all subsequent requests.
+  // * Generates a request id and filters by it
+  // * Send `end_subscription` when observable is unsubscribed
+  makeRequest(rawRequest) {
+    const request = this.getRequest(rawRequest)
+
+    return super.multiplex(
+      this.activateRequest(request),
+      this.deactivateRequest(request),
+      this.filterRequest(request)
+    )
+  }
+
+  // Wrapper around the makeRequest with the following additional
+  // features we need for horizon's protocol:
+  // * Sends handshake on subscription if it hasn't happened already
+  // * Wait for the handshake to complete before sending the request
+  // * Errors when a document with an `error` field is received
+  // * Completes when `state: complete` is received
+  // * Emits `state: synced` as a separate document for easy filtering
+  // * Reference counts subscriptions
+  hzRequest(rawRequest) {
+    return this.handshake.ignoreElements()
+      .concat(this.makeRequest(rawRequest))
+      .concatMap(resp => {
+        if (resp.error !== undefined) {
+          throw new ProtocolError(resp.error, resp.error_code)
+        }
+        const data = resp.data || []
+
+        if (resp.state !== undefined) {
+          // Create a little dummy object for sync notifications
+          data.push({
+            type: 'state',
+            state: resp.state,
+          })
+        }
+
+        return data
+      })
+      .share()
+  }
+}


### PR DESCRIPTION
Implements #276, #527 (client side at least), and should fix #595 directly.

Turns out it can't be used in a "composed" way since it does some stuff that needs to be overridden. So this is subclassing WebSocketSubject in a way that kind of throws out a bit of its functionality and implements some functionality we need like handshakes and messages that complete requests (`state: complete` should finish a multiplexed observable)

This is also laying the foundation for #358 by keeping an internal map of requests so they can be re-sent later upon reconnection. That functionality won't land in 2.0 however

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/619)

<!-- Reviewable:end -->
