### PR TITLE
findAll auth doesn't allow for specifying keys

### DIFF
--- a/server/test/permissions.js
+++ b/server/test/permissions.js
@@ -97,6 +97,30 @@ describe('Permissions', () => {
       assert(rule.is_match(make_request('query', 'test', { find_all: [ { } ], fake: 'baz' }), context));
     });
 
+    it('single key in findAll', () => {
+      const rule = new Rule('foo', { template: 'collection("test").findAll({ owner: userId() }).fetch()' });
+      assert(rule.is_valid());
+      assert(!rule.is_match(make_request('query', 'test', { findAll: { } }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: true }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ ] }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ { bar: 'baz' } ] }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ { owner: (context.id + 1) } ] }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ { owner: context.id, bar: 'baz' } ] }), context));
+      assert(rule.is_match(make_request('query', 'test', { findAll: [ { owner: context.id } ] }), context));
+    });
+
+    it('multiple keys in findAll', () => {
+      const rule = new Rule('foo', { template: 'collection("test").findAll({ owner: userId(), key: any() }).fetch()' });
+      assert(rule.is_valid());
+      assert(!rule.is_match(make_request('query', 'test', { findAll: { } }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: true }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ ] }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ { bar: 'baz' } ] }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ { owner: (context.id + 1) } ] }), context));
+      assert(!rule.is_match(make_request('query', 'test', { findAll: [ { owner: context.id, bar: 'baz' } ] }), context));
+      assert(rule.is_match(make_request('query', 'test', { findAll: [ { owner: context.id, key: 123 } ] }), context));
+    });
+
     it('collection fetch', () => {
       const rule = new Rule('foo', { template: 'collection("test").fetch()' });
       assert(rule.is_valid());


### PR DESCRIPTION
The auth template `collection("test").findAll({ owner: userId() }).fetch()` fails for a request like `{"request_id":5,"type":"query","options":{"collection":"test","find_all":[{"owner":"123"}]}}`.

I've included a failing test for this. 

Is this a bug, has the feature not been implemented yet (https://github.com/rethinkdb/horizon/blob/6d61901/server/test/permissions.js#L65 seems to suggest this). Or am I just doing this incorrectly?

I think this is related to https://github.com/rethinkdb/horizon/issues/552

I'm happy to work on this feature if no one else is. Even if it's just to throw an error when a template like this is specified.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/624)

<!-- Reviewable:end -->
