### PR TITLE
Wait for internal db on startup and always print error message on reql connection failure

### DIFF
--- a/server/src/metadata/metadata.js
+++ b/server/src/metadata/metadata.js
@@ -65,9 +65,34 @@ class Metadata {
     this._group_feed = null;
     this._index_feed = null;
 
-    const make_feeds = () => {
-      logger.debug('running metadata sync');
-      const groups_ready =
+    this._ready_promise = Promise.resolve().then(() => {
+      logger.debug('checking for internal db/tables');
+      if (this._auto_create_collection) {
+        return initialize_metadata_reql(r, this._internal_db, this._db).run(this._conn)
+      } else {
+        return r.expr([ this._db, this._internal_db ])
+                 .concatMap((db) => r.branch(r.dbList().contains(db), [], [ db ]))
+                 .run(this._conn)
+                 .then((missing_dbs) => {
+          if (missing_dbs.length > 0) {
+            let err_msg;
+            if (missing_dbs.length === 1) {
+              err_msg = `The database ${missing_dbs[0]} does not exist.`;
+            } else {
+              err_msg = `The databases ${missing_dbs.join(' and ')} do not exist.`;
+            }
+            throw new Error(err_msg + '  Run `hz set-schema` to initialize the database, ' +
+                            'then start the Horizon server.');
+          }
+        });
+      }
+    }).then(() => {
+      logger.debug('waiting for internal db');
+      return r.db(this._internal_db).wait({ timeout: 30 }).run(this._conn)
+    }).then(() => {
+      logger.debug('syncing metadata changefeeds');
+      return Promise.all([
+        // Groups changefeed
         r.db(this._internal_db)
           .table('groups')
           .changes({ squash: true,
@@ -102,8 +127,9 @@ class Metadata {
                 }
               }).catch(reject);
             });
-          });
-      const collections_ready =
+          }),
+
+        // Collections changefeed
         r.db(this._internal_db)
           .table('collections')
           .changes({ squash: false,
@@ -154,8 +180,9 @@ class Metadata {
                 }
               }).catch(reject);
             });
-          });
-      const indexes_ready =
+          }),
+
+        // Indexes changefeed
         r.db('rethinkdb')
           .table('table_config')
           .filter({ db: this._db })
@@ -201,35 +228,8 @@ class Metadata {
                 }
               }).catch(reject);
             });
-          });
-      return Promise.all([ groups_ready, collections_ready, indexes_ready ]);
-    };
-
-    if (this._auto_create_collection) {
-      this._ready_promise =
-        initialize_metadata_reql(r, this._internal_db, this._db).run(this._conn).then(make_feeds);
-    } else {
-      this._ready_promise =
-        r.expr([ this._db, this._internal_db ])
-         .concatMap((db) => r.branch(r.dbList().contains(db), [], [ db ]))
-         .run(this._conn).then((missing_dbs) => {
-           logger.debug('checking for internal db/tables');
-           if (missing_dbs.length > 0) {
-             let err_msg;
-             if (missing_dbs.length === 1) {
-               err_msg = `The database ${missing_dbs[0]} does not exist.`;
-             } else {
-               err_msg = `The databases ${missing_dbs.join(' and ')} do not exist.`;
-             }
-             throw new Error(err_msg + 'Run `hz set-schema` to initialize the database, ' +
-                             'then start the Horizon server.');
-           } else {
-             return make_feeds();
-           }
-         });
-    }
-
-    this._ready_promise = this._ready_promise.then(() => {
+          }) ]);
+    }).then(() => {
       logger.debug('adding admin user');
       // Ensure that the admin user and group exists
       return Promise.all([

--- a/server/src/metadata/metadata.js
+++ b/server/src/metadata/metadata.js
@@ -91,8 +91,8 @@ class Metadata {
       return r.db(this._internal_db).wait({ timeout: 30 }).run(this._conn)
     }).then(() => {
       logger.debug('syncing metadata changefeeds');
-      return Promise.all([
-        // Groups changefeed
+
+      const group_changefeed =
         r.db(this._internal_db)
           .table('groups')
           .changes({ squash: true,
@@ -127,9 +127,9 @@ class Metadata {
                 }
               }).catch(reject);
             });
-          }),
+          });
 
-        // Collections changefeed
+      const collection_changefeed =
         r.db(this._internal_db)
           .table('collections')
           .changes({ squash: false,
@@ -180,9 +180,9 @@ class Metadata {
                 }
               }).catch(reject);
             });
-          }),
+          });
 
-        // Indexes changefeed
+      const index_changefeed =
         r.db('rethinkdb')
           .table('table_config')
           .filter({ db: this._db })
@@ -228,7 +228,9 @@ class Metadata {
                 }
               }).catch(reject);
             });
-          }) ]);
+          });
+
+      return Promise.all([ group_changefeed, collection_changefeed, index_changefeed ]);
     }).then(() => {
       logger.debug('adding admin user');
       // Ensure that the admin user and group exists

--- a/server/src/reql_connection.js
+++ b/server/src/reql_connection.js
@@ -104,8 +104,7 @@ class ReqlConnection {
        this._ready = true;
        resolve(this);
      }).catch((err) => {
-       if (err instanceof r.Error.ReqlDriverError ||
-           err instanceof r.Error.ReqlAvailabilityError) {
+       if (err instanceof r.Error.ReqlAvailabilityError) {
          logger.debug(`Connection to RethinkDB terminated: ${err}`);
        } else {
          logger.error(`Connection to RethinkDB terminated: ${err}`);

--- a/server/src/reql_connection.js
+++ b/server/src/reql_connection.js
@@ -99,7 +99,7 @@ class ReqlConnection {
                                      this._auto_create_index);
        return this._metadata.ready();
      }).then(() => {
-       logger.info('Metadata synced with database, ready for traffic.');
+       logger.info(`Connection to RethinkDB ready: ${this._user} @ ${this._host}:${this._port}`);
        this._reconnect_delay = 0;
        this._ready = true;
        resolve(this);

--- a/server/src/reql_connection.js
+++ b/server/src/reql_connection.js
@@ -104,11 +104,7 @@ class ReqlConnection {
        this._ready = true;
        resolve(this);
      }).catch((err) => {
-       if (err instanceof r.Error.ReqlAvailabilityError) {
-         logger.debug(`Connection to RethinkDB terminated: ${err}`);
-       } else {
-         logger.error(`Connection to RethinkDB terminated: ${err}`);
-       }
+       logger.error(`Connection to RethinkDB terminated: ${err}`);
        logger.debug(`stack: ${err.stack}`);
        retry();
      });

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -188,7 +188,7 @@ class Server {
   }
 
   ready() {
-    return this._reql_conn.ready();
+    return this._reql_conn.ready().then(() => this);
   }
 
   close() {


### PR DESCRIPTION
As part of the fix for #639, these changes should make it more obvious when there is a connection problem to the database.  Reorganized some of the code in the `Metadata` constructor to be a more linear promise chain as part of this.

This does not address all aspects of #639, as these is still no mechanism for passing errors to the user of the `Server` object when there is connectivity problems with the database - it is only reported through the logger.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/644)

<!-- Reviewable:end -->
