### PR TITLE
handshake on multiplex subscription

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,7 +5,6 @@ import 'rxjs/add/operator/concatMap'
 import 'rxjs/add/operator/map'
 import 'rxjs/add/operator/filter'
 
-import * as Rx from 'rxjs'
 import { Collection, UserDataTerm } from './ast'
 import { HorizonSocket } from './socket'
 import { log, logError, enableLogging } from './logging'

--- a/client/test/horizonObject.js
+++ b/client/test/horizonObject.js
@@ -47,28 +47,19 @@ var horizonObjectSuite = global.horizonObjectSuite = () => {
       // Note -- the connection string specifies a bad host.
       const horizon = Horizon({
         host: 'wrong_host',
-        secure: false
+        secure: false,
       })
       assert.isDefined(horizon)
-      let val = 0
-      horizon.status().subscribe(status => {
-        if (status.type === 'unconnected') {
-          assert.equal(val, 0)
-          assert.deepEqual(status, { type: 'unconnected' })
-          val += 1
-        } else if (status.type === 'error') {
-          assert.equal(val, 1)
-          assert.deepEqual(status, { type: 'error' })
-          val += 1
-        } else if (status.type === 'disconnected') {
-          assert.equal(val, 2)
-          assert.deepEqual(status, { type: 'disconnected' })
-          done()
-        } else {
-          done(new Error(`Got unexpected status: ${status.type}`))
-        }
+      horizon.status().take(3).toArray().subscribe(statuses => {
+        const expected = [
+          { type: 'unconnected' },
+          { type: 'error' }, // socket
+          { type: 'disconnected' },
+        ]
+        assert.deepEqual(expected, statuses)
+        done()
       })
-      horizon.connect(() => {}) // no-op error handler, already covered
+      horizon.connect() // no-op error handler, already covered
     })
   })
 }


### PR DESCRIPTION
Fixes #567, which extended to all read queries: none of them would cause a handshake, so but they would block on the handshake, so they'd have to wait until a write query or an explicit `.subscribe` was called. Now we explicitly send the handshake on each request unless we've already sent it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/653)

<!-- Reviewable:end -->
