### PR TITLE
fix: properly change items with array ids

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "babel-runtime": "^6.6.1",
     "core-js": "^2.1.0",
+    "deep-equal": "^1.0.1",
     "es6-promise": "^3.2.1",
     "rxjs": ">=5.0.0-beta.10",
     "snake-case": "^1.1.2",

--- a/client/src/ast.js
+++ b/client/src/ast.js
@@ -10,6 +10,7 @@ import 'rxjs/add/operator/take'
 import 'rxjs/add/operator/defaultIfEmpty'
 
 import snakeCase from 'snake-case'
+import deepEqual from 'deep-equal'
 
 import checkArgs from './util/check-args'
 import validIndexValue from './util/valid-index-value.js'
@@ -186,7 +187,14 @@ export function applyChange(arr, change) {
     } else {
       // If we don't have an offset, find the old val and
       // replace it with the new val
-      const index = arr.findIndex(x => x.id === change.old_val.id)
+      const index = arr.findIndex(x => deepEqual(x.id, change.old_val.id))
+      if (index === -1) {
+        // indicates a programming bug. The server gives us the
+        // ordering, so if we don't find the id it means something is
+        // buggy.
+        throw new Error(
+          `change couldn't be applied: ${JSON.stringify(change)}`)
+      }
       arr[index] = change.new_val
     }
     break

--- a/client/test/api.js
+++ b/client/test/api.js
@@ -120,5 +120,6 @@ describe('Core API tests', () => {
   describe('Unit tests', () => {
     describe('Auth', unitAuthSuite)
     describe('Utils', unitUtilsSuite)
+    describe('AST', unitAstSuite)
   })
 }) // Core API tests

--- a/client/test/test.js
+++ b/client/test/test.js
@@ -102,6 +102,7 @@ require('./orderLimitSub.js')
 // Unit tests
 require('./unit/auth.js')
 require('./unit/utilsTest.js')
+require('./unit/ast.js')
 
 // Load the suite runner
 require('./api.js')

--- a/client/test/unit/ast.js
+++ b/client/test/unit/ast.js
@@ -1,0 +1,32 @@
+import { applyChange } from '../../src/ast'
+
+const unitAstSuite = global.unitAstSuite = () => {
+  describe('applyChanges', () => {
+    it('correctly replaces an item with an array id', done => {
+      const existingArray = [
+        { id: [ 'A', 'B' ], val: 3 },
+        { id: [ 'B', 'C' ], val: 4 },
+      ]
+      const change = {
+        type: 'change',
+        new_offset: null,
+        old_offset: null,
+        old_val: {
+          id: [ 'B', 'C' ],
+          val: 4,
+        },
+        new_val: {
+          id: [ 'B', 'C' ],
+          val: 5,
+        },
+      }
+      const expected = [
+        { id: [ 'A', 'B' ], val: 3 },
+        { id: [ 'B', 'C' ], val: 5 },
+      ]
+      const obtained = applyChange(existingArray, change)
+      assert.deepEqual(obtained, expected)
+      done()
+    })
+  })
+}


### PR DESCRIPTION
Fixes #649 

Added a unit test for it. Adds a dependency on `deep-equal`, and throws an error if we get a negative index for any reason, rather than silently corrupting the data

Thanks to @daniel1943 for patiently reproducing and @marshall007 for finding the bug

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/656)

<!-- Reviewable:end -->
