### PR TITLE
serve.js script: On Windows, spawn `npm.cmd` instead of `npm`

### DIFF
--- a/test/serve.js
+++ b/test/serve.js
@@ -78,8 +78,11 @@ const serve_file = (file_path, res) => {
   });
 };
 
+// On Windows, `npm` is actually `npm.cmd`
+const npm_cmd = process.platform === "win32" ? "npm.cmd" : "npm";
+
 // Run the client build
-const build_proc = child_process.spawn('npm', [ 'run', 'dev'],
+const build_proc = child_process.spawn(npm_cmd, [ 'run', 'dev'],
                                       { cwd: test_dist_dir });
 
 build_proc.on('exit', () => process.exit(1));


### PR DESCRIPTION
On Windows, there is no `npm` but only `npm.cmd`, at least when installing `node` using the official installer.
See http://stackoverflow.com/a/17537559/2413884 for details.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/658)

<!-- Reviewable:end -->
