### PR TITLE
Adding --clean flag to reduce build times on CircleCI

### DIFF
--- a/test/setupDev.sh
+++ b/test/setupDev.sh
@@ -5,7 +5,7 @@ green () {
     echo -e "\033[1;32m== $1 \033[0m"
 }
 
-if [ $1 == '--clean' ]; then
+if [ "$1" == '--clean' ]; then
  green 'Removing old node_modules dirs if present'
  if [ -d ../client/node_modules ]; then
    echo Removing client/node_modules

--- a/test/setupDev.sh
+++ b/test/setupDev.sh
@@ -25,7 +25,7 @@ pushd ../client
 green 'Unlinking existing client'
 npm unlink
 green 'Linking client'
-npm link --unsafe-perm
+npm link --unsafe-perm --cache-min 9999999
 popd
 
 pushd ../server
@@ -33,7 +33,7 @@ green 'Unlinking existing server'
 npm unlink
 green 'Linking server'
 npm link @horizon/client
-npm link
+npm link --cache-min 9999999
 popd
 
 pushd ../cli
@@ -41,7 +41,7 @@ green 'Unlinking existing horizon cli'
 npm unlink
 green 'Linking horizon cli'
 npm link @horizon/server
-npm link
+npm link --cache-min 9999999
 popd
 
 green 'Dev environment set up'

--- a/test/setupDev.sh
+++ b/test/setupDev.sh
@@ -5,18 +5,20 @@ green () {
     echo -e "\033[1;32m== $1 \033[0m"
 }
 
-green 'Removing old node_modules dirs if present'
-if [ -d ../client/node_modules ]; then
-  echo Removing client/node_modules
-  rm -r ../client/node_modules
-fi
-if [ -d ../server/node_modules ]; then
+if [ $1 == '--clean' ]; then
+ green 'Removing old node_modules dirs if present'
+ if [ -d ../client/node_modules ]; then
+   echo Removing client/node_modules
+   rm -r ../client/node_modules
+ fi
+ if [ -d ../server/node_modules ]; then
   echo Removing server/node_modules
   rm -r ../server/node_modules
-fi
-if [ -d ../cli/node_modules ]; then
+ fi
+ if [ -d ../cli/node_modules ]; then
   echo Removing cli/node_modules
   rm -r ../cli/node_modules
+ fi
 fi
 
 pushd ../client


### PR DESCRIPTION
On fresh repo with blown away `node_modules`
`./setupDev.sh --clean  90.32s user 25.52s system 59% cpu 3:13.35 total`

On pre-setup repo with `node_modules` already installed
`./setupDev.sh  38.08s user 4.14s system 104% cpu 40.523 total`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/673)

<!-- Reviewable:end -->
