### PR TITLE
CLI parsing rework

### DIFF
--- a/cli/src/create-cert.js
+++ b/cli/src/create-cert.js
@@ -1,10 +1,16 @@
 'use strict';
 const hasbin = require('hasbin');
 const spawn = require('child_process').spawn;
+const process = require('process');
 
 const helpText = 'Generate a certificate';
 
-const runCommand = () => {
+const runCommand = (args) => {
+  if (args.length) {
+    console.error("create-cert takes no arguments");
+    process.exit(1);
+  }
+
   // TODO: user configuration?
   const settings = {
     binaryName: 'openssl',
@@ -56,13 +62,7 @@ const runCommand = () => {
   });
 };
 
-const processConfig = () => ({});
-
-const addArguments = () => {};
-
 module.exports = {
-  addArguments,
-  processConfig,
   runCommand,
   helpText,
 };

--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const crypto = require('crypto');
 const process = require('process');
+const argparse = require('argparse');
 const checkProjectName = require('./utils/check-project-name');
 const rethrow = require('./utils/rethrow');
 
@@ -156,13 +157,15 @@ rethinkdb_data
 .hz/secrets.toml
 `
 
-const addArguments = (parser) => {
+function parseArguments(args) {
+  const parser = new argparse.ArgumentParser({prog: 'hz init'});
   parser.addArgument([ 'projectName' ],
     { action: 'store',
       help: 'Name of directory to create. Defaults to current directory',
       nargs: '?',
     }
   );
+  return parser.parseArgs(args);
 };
 
 const fileExists = (pathName) => {
@@ -173,8 +176,6 @@ const fileExists = (pathName) => {
     return false;
   }
 };
-
-const processConfig = (parsed) => parsed;
 
 function maybeMakeDir(createDir, dirName) {
   if (createDir) {
@@ -283,7 +284,8 @@ function populateDir(projectName, dirWasPopulated, chdirTo, dirName) {
   }
 }
 
-const runCommand = (parsed) => {
+function runCommand(args) {
+  const parsed = parseArguments(args);
   const check = checkProjectName(
     parsed.projectName,
     process.cwd(),
@@ -303,8 +305,6 @@ const runCommand = (parsed) => {
 
 
 module.exports = {
-  addArguments,
   runCommand,
-  processConfig,
   helpText,
 };

--- a/cli/src/main.js
+++ b/cli/src/main.js
@@ -6,6 +6,8 @@ process.title = 'horizon';
 
 const argparse = require('argparse');
 const chalk = require('chalk');
+const path = require('path');
+
 const initCommand = require('./init');
 const serveCommand = require('./serve');
 const versionCommand = require('./version');
@@ -16,55 +18,72 @@ const makeTokenCommand = require('./make-token');
 // Mapping from command line strings to modules. To add a new command,
 // add an entry in this object, and create a module with the following
 // exported:
-// - processConfig: merge parsed command line options with config
 // - runCommand: main function for the command
-// - addArguments: receives a parser and adds any options it needs
 // - helpText: a string to display in the hz help text
 const commands = {
-  init: initCommand,
-  serve: serveCommand,
-  version: versionCommand,
-  'create-cert': createCertCommand,
-  'make-token': makeTokenCommand,
-  schema: schemaCommand,
 };
 
-function parseArgs() {
-  const parser = new argparse.ArgumentParser();
-  const subparsers = parser.addSubparsers({
-    title: 'commands',
-    dest: 'command_name',
-  });
+const programName = path.basename(process.argv[1]);
 
-  Object.keys(commands).forEach((commandName) => {
-    const command = commands[commandName];
-    const subparser = subparsers.addParser(commandName, {
-      addHelp: true,
-      help: command.helpText,
-    });
-    command.addArguments(subparser);
+function attachOldCommand(name, cmd) {
+  const newCmd = Object.assign({}, cmd, {
+    runCommand: function (args, done) {
+      const parser = new argparse.ArgumentParser({prog: `${programName} ${name}`});
+      cmd.addArguments(parser);
+      const opts = cmd.processConfig(parser.parseArgs(args));
+      cmd.runCommand(opts, done);
+    },
   });
-
-  return parser.parseArgs();
+  commands[name] = newCmd;
 }
 
-function runCommand(command, parsedOptions) {
-  const options = command.processConfig(parsedOptions);
-  const done = (err) => {
-    if (err) {
-      console.log(chalk.red.bold(
-        `${parsedOptions.command_name} failed ` +
-          `with ${options.debug ? err.stack : err}`));
-      process.exit(1);
-    }
-  };
-  try {
-    command.runCommand(options, done);
-  } catch (e) {
-    done(e);
+attachOldCommand("init", initCommand);
+attachOldCommand("serve", serveCommand);
+attachOldCommand("version", versionCommand);
+attachOldCommand("create-cert", createCertCommand);
+attachOldCommand("make-token", makeTokenCommand);
+attachOldCommand("schema", schemaCommand);
+
+function help() {
+  console.log(`Usage: ${programName} subcommand [args...]`);
+  console.log(`Available subcommands:`);
+  Object.keys(commands).forEach(function (cmdName) {
+    console.log(`  ${cmdName} - ${commands[cmdName].helpText}`);
+  });
+}
+
+const allArgs = process.argv.slice(2);
+if (allArgs.length == 0) {
+  help();
+  process.exit(1);
+}
+
+const cmdName = allArgs[0];
+const cmdArgs = allArgs.slice(1);
+
+if (cmdName == "-h" || cmdName == "--help" || cmdName == "help") {
+  help();
+  process.exit(0);
+}
+
+var command = commands[cmdName];
+if (!command) {
+  console.log(chalk.red.bold(
+    `No such subcommand ${cmdName}, run with -h for help`));
+  process.exit(1);
+}
+
+function done(err) {
+  if (err) {
+    console.log(chalk.red.bold(
+      `${cmdName} failed ` +
+      `with ${err.stack}`));
+    process.exit(1);
   }
+};
+
+try {
+  command.runCommand(cmdArgs, done);
+} catch (e) {
+  done(e);
 }
-
-const parsed = parseArgs();
-
-runCommand(commands[parsed.command_name], parsed);

--- a/cli/src/main.js
+++ b/cli/src/main.js
@@ -4,7 +4,6 @@
 // To support `pidof horizon`, by default it shows in `pidof node`
 process.title = 'horizon';
 
-const argparse = require('argparse');
 const chalk = require('chalk');
 const path = require('path');
 
@@ -21,28 +20,15 @@ const makeTokenCommand = require('./make-token');
 // - runCommand: main function for the command
 // - helpText: a string to display in the hz help text
 const commands = {
+  init: initCommand,
+  serve: serveCommand,
+  version: versionCommand,
+  'create-cert': createCertCommand,
+  'make-token': makeTokenCommand,
+  schema: schemaCommand,
 };
 
 const programName = path.basename(process.argv[1]);
-
-function attachOldCommand(name, cmd) {
-  const newCmd = Object.assign({}, cmd, {
-    runCommand: function (args, done) {
-      const parser = new argparse.ArgumentParser({prog: `${programName} ${name}`});
-      cmd.addArguments(parser);
-      const opts = cmd.processConfig(parser.parseArgs(args));
-      cmd.runCommand(opts, done);
-    },
-  });
-  commands[name] = newCmd;
-}
-
-attachOldCommand("init", initCommand);
-attachOldCommand("serve", serveCommand);
-attachOldCommand("version", versionCommand);
-attachOldCommand("create-cert", createCertCommand);
-attachOldCommand("make-token", makeTokenCommand);
-attachOldCommand("schema", schemaCommand);
 
 function help() {
   console.log(`Usage: ${programName} subcommand [args...]`);

--- a/cli/src/make-token.js
+++ b/cli/src/make-token.js
@@ -10,10 +10,13 @@ const jwt = require('jsonwebtoken');
 
 const r = horizon_server.r;
 const logger = horizon_server.logger;
+const argparse = require('argparse');
 
 const helpText = 'Generate a token to log in as a user';
 
-const addArguments = (parser) => {
+function parseArguments(args) {
+  const parser = new argparse.ArgumentParser({prog: "hz make-token"});
+
   parser.addArgument([ 'project_path' ],
     { type: 'string', nargs: '?',
       help: 'Change to this directory before serving' });
@@ -45,7 +48,9 @@ const addArguments = (parser) => {
   parser.addArgument([ 'user' ],
     { type: 'string', metavar: 'USER_ID',
       help: 'The ID of the user to issue a token for.' });
-};
+
+  return parser.parseArgs(args);
+}
 
 const processConfig = (parsed) => {
   let config;
@@ -65,7 +70,9 @@ const processConfig = (parsed) => {
   return Object.assign(config, { user: parsed.user });
 };
 
-const runCommand = (options, done) => {
+const runCommand = (args, done) => {
+  const options = processConfig(parseArguments(args));
+
   const db = options.project_name;
   let conn;
 
@@ -116,8 +123,6 @@ const runCommand = (options, done) => {
 };
 
 module.exports = {
-  addArguments,
-  processConfig,
   runCommand,
   helpText,
 };

--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -8,6 +8,7 @@ const http = require('http');
 const https = require('https');
 const open = require('open');
 const path = require('path');
+const argparse = require('argparse');
 const toml = require('toml');
 const url = require('url');
 
@@ -31,7 +32,9 @@ const default_rdb_timeout = 20;
 
 const helpText = 'Serve a Horizon app';
 
-const addArguments = (parser) => {
+function parseArguments(args) {
+  const parser = new argparse.ArgumentParser({prog: "hz serve"});
+
   parser.addArgument([ 'project_path' ],
     { type: 'string', nargs: '?',
       help: 'Change to this directory before serving' });
@@ -152,7 +155,9 @@ const addArguments = (parser) => {
     { action: 'storeTrue',
       help: 'Open index.html in the static files folder once Horizon is ready to' +
       ' receive connections' });
-};
+
+  return parser.parseArgs(args);
+}
 
 const make_default_config = () => ({
   config: null,
@@ -674,7 +679,9 @@ const change_to_project_dir = (project_path) => {
 };
 
 // Actually serve based on the already validated options
-const runCommand = (opts, done) => {
+const runCommand = (args, done) => {
+  const opts = processConfig(parseArguments(args));
+
   if (opts.debug) {
     logger.level = 'debug';
   } else {
@@ -765,8 +772,6 @@ const runCommand = (opts, done) => {
   }).catch(done);
 };
 
-serve.addArguments = addArguments;
-serve.processConfig = processConfig;
 serve.runCommand = runCommand;
 serve.helpText = helpText;
 serve.merge_configs = merge_configs;

--- a/cli/src/version.js
+++ b/cli/src/version.js
@@ -8,13 +8,7 @@ const runCommand = () => {
   console.info(package_json.version);
 };
 
-const processConfig = () => ({});
-
-const addArguments = () => {};
-
 module.exports = {
-  addArguments,
-  processConfig,
   runCommand,
   helpText,
 };


### PR DESCRIPTION
This changes the command module interface to push a bit more of the work to the modules themselves. It should make implementing plugins and the `cloud` subcommand simpler.

The new interface has one method, `runCommand`, which now takes the argument array after the command (instead of an `argparse.Namespace`), and `helpText` as it was before as a description of the command. `processConfig` and `addArguments` are no longer part of the command module API.

Some modules still have `processConfig`, but it's a function entirely local to the command module and is not called by `main.js`.

Pinging @Tryneus for review.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/690)

<!-- Reviewable:end -->
