### PR TITLE
Added support for Horizon deploy to Google App Engine flexible environment

### DIFF
--- a/server/src/gae.js
+++ b/server/src/gae.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const logger = require('./logger');
+const auth_utils = require('./auth/utils');
+
+const http = require('http');
+
+const make_meta_request = (path) => {
+  const req = http.request({
+    protocol: 'http:',
+    host: 'metadata.google.internal',
+    path: `/computeMetadata/v1${path}`,
+    headers: {
+      'Metadata-Flavor': 'Google',
+    } });
+  req.setTimeout(750);
+  return req;
+};
+
+const run_meta_request = (path, cb) => {
+  auth_utils.run_request(make_meta_request(path), (err, body) => {
+    if (err) {
+      logger.error(`Failed to obtain GCE meta "${path}": ${err}`);
+    }
+    cb(err, body);
+  });
+};
+
+const get_internal_ip = (cb) =>
+  run_meta_request('/instance/network-interfaces/0/ip', cb);
+
+const get_external_ip = (cb) =>
+  run_meta_request('/instance/network-interfaces/0/access-configs/0/external-ip', cb);
+
+const get_ips = (cb) => {
+  get_internal_ip((err, internal_ip) => {
+    if (err) {
+      return cb(err);
+    }
+    get_external_ip((err2, external_ip) => {
+      if (err2) {
+        return cb(err2);
+      }
+      cb(null, {
+        internal_ip,
+        external_ip,
+      });
+    });
+  });
+};
+
+module.exports = {
+  get_ips,
+  get_internal_ip,
+  get_external_ip,
+};

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const gae = require('./gae');
 const Auth = require('./auth').Auth;
 const Client = require('./client').Client;
 const ReqlConnection = require('./reql_connection').ReqlConnection;
@@ -147,6 +148,16 @@ class Server {
     this.add_http_handler('auth_methods', (req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': opts.access_control_allow_origin });
       res.end(JSON.stringify(this._auth_methods));
+    });
+
+    this.add_http_handler('gae', (req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': opts.access_control_allow_origin });
+      gae.get_ips((err, ips) => {
+        if (err) {
+          res.statusCode = 500;
+        }
+        res.end(JSON.stringify(ips || {}));
+      });
     });
 
     if (http_servers.forEach === undefined) {


### PR DESCRIPTION
The Horizon javascript client optionally fetches Google Cloud Engine (GAE
flexible environment) external and internal IP address, completes the WS url
and only then connects to Horizon WS service.

This all happens only if the new option gaeInstanceIp is set with value 'external'
for GCE instance public or 'internal' for private IP address.

Horizon Google App Engine standard environment deployment is not supported.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/693)

<!-- Reviewable:end -->
