### PR TITLE
Handle Errors in deserialize function

### DIFF
--- a/client/src/serialization.js
+++ b/client/src/serialization.js
@@ -3,12 +3,22 @@ const PRIMITIVES = [
 
 function modifyObject(doc) {
   Object.keys(doc).forEach(key => {
-    doc[key] = deserialize(doc[key])
+    doc[key] = deserialize(doc[key], true)
   })
   return doc
 }
 
-export function deserialize(value) {
+class ProtocolError extends Error {
+  constructor(msg, errorCode) {
+    super(msg)
+    this.errorCode = errorCode
+  }
+  toString() {
+    return `${this.message} (Code: ${this.errorCode})`
+  }
+}
+
+export function deserialize(value, nested) {
   if (value == null) {
     return value
   } else if (PRIMITIVES.indexOf(typeof value) !== -1) {
@@ -19,6 +29,8 @@ export function deserialize(value) {
     const date = new Date()
     date.setTime(value.epoch_time * 1000)
     return date
+  } else if (value.error !== undefined && nested !== true) {
+    throw new ProtocolError(value.error, value.error_code)
   } else {
     return modifyObject(value)
   }

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -24,16 +24,6 @@ const STATUS_ERROR = { type: 'error' }
 // Occurs when the socket closes
 const STATUS_DISCONNECTED = { type: 'disconnected' }
 
-class ProtocolError extends Error {
-  constructor(msg, errorCode) {
-    super(msg)
-    this.errorCode = errorCode
-  }
-  toString() {
-    return `${this.message} (Code: ${this.errorCode})`
-  }
-}
-
 
 // Wraps native websockets with a Subject, which is both an Subscriber
 // and an Observable (it is bi-directional after all!). This version
@@ -176,9 +166,6 @@ export class HorizonSocket extends WebSocketSubject {
     return this.sendHandshake().ignoreElements()
       .concat(this.makeRequest(rawRequest))
       .concatMap(resp => {
-        if (resp.error !== undefined) {
-          throw new ProtocolError(resp.error, resp.error_code)
-        }
         const data = resp.data || []
 
         if (resp.state !== undefined) {


### PR DESCRIPTION
Fix for Issue #712 so that any message with an error key in the top level of the message throws an error in the client.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/713)

<!-- Reviewable:end -->
