### PR TITLE
Max simultaneous connections flag for server

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -33,7 +33,7 @@ const default_rdb_timeout = 20;
 const helpText = 'Serve a Horizon app';
 
 function parseArguments(args) {
-  const parser = new argparse.ArgumentParser({prog: "hz serve"});
+  const parser = new argparse.ArgumentParser({ prog: 'hz serve' });
 
   parser.addArgument([ 'project_path' ],
     { type: 'string', nargs: '?',
@@ -87,6 +87,10 @@ function parseArguments(args) {
   parser.addArgument([ '--allow-anonymous' ],
     { type: 'string', metavar: 'yes|no', constant: 'yes', nargs: '?',
       help: 'Whether to allow anonymous Horizon connections.' });
+
+  parser.addArgument([ '--max-connections' ],
+    { type: 'int', metavar: 'MAX_CONNECTIONS',
+      help: 'Maximum number of simultaneous connections server will accept.' });
 
   parser.addArgument([ '--debug' ],
     { type: 'string', metavar: 'yes|no', constant: 'yes', nargs: '?',
@@ -194,6 +198,7 @@ const make_default_config = () => ({
   allow_unauthenticated: false,
   auth_redirect: '/',
   access_control_allow_origin: '',
+  max_connections: null,
 
   auth: { },
 });
@@ -548,6 +553,11 @@ const read_config_from_flags = (parsed) => {
     config.access_control_allow_origin = parsed.access_control_allow_origin;
   }
 
+  if (parsed.max_connections !== null &&
+      parsed.max_connections !== undefined) {
+    config.max_connections = parsed.max_connections;
+  }
+
   // Auth options
   if (parsed.auth !== null && parsed.auth !== undefined) {
     parsed.auth.forEach((auth_options) => {
@@ -649,6 +659,7 @@ const startHorizonServer = (servers, opts) => {
     rdb_user: opts.rdb_user || null,
     rdb_password: opts.rdb_password || null,
     rdb_timeout: opts.rdb_timeout || null,
+    max_connections: opts.max_connections || null,
   });
   const timeoutObject = setTimeout(() => {
     console.log(chalk.red.bold('Horizon failed to start after 30 seconds'));

--- a/server/src/client.js
+++ b/server/src/client.js
@@ -33,6 +33,10 @@ class Client {
     if (!this._metadata.is_ready()) {
       this.close({ error: 'No connection to the database.' });
     }
+
+    if (server._max_connections !== null && server._reql_conn._clients.size > server._max_connections) {
+      this.close({ request_id: null, error: 'Max connections limit reached.', error_code: 0 });
+    }
   }
 
   handle_websocket_close() {

--- a/server/src/schema/server_options.js
+++ b/server/src/schema/server_options.js
@@ -20,6 +20,7 @@ const server = Joi.object({
   rdb_user: Joi.string().allow(null),
   rdb_password: Joi.string().allow(null),
   rdb_timeout: Joi.number().allow(null),
+  max_connections: Joi.number().allow(null),
 }).unknown(false);
 
 const auth = Joi.object({

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -72,6 +72,7 @@ class Server {
     this._r = r;
     this._path = opts.path;
     this._name = opts.project_name;
+    this._max_connections = opts.max_connections;
     this._permissions_enabled = opts.permissions;
     this._auth_methods = { };
     this._request_handlers = new Map();


### PR DESCRIPTION
This is my proposed solution for #709 
Allow optional flag to limit the number of clients that can connect at one time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/714)

<!-- Reviewable:end -->
