### PR TITLE
Change collection creation behavior again

### DIFF
--- a/cli/src/schema.js
+++ b/cli/src/schema.js
@@ -19,7 +19,7 @@ const argparse = require('argparse');
 const toml = require('toml');
 
 const r = horizon_server.r;
-const create_collection_reql = horizon_metadata.create_collection_reql;
+const create_collection = horizon_metadata.create_collection;
 const initialize_metadata = horizon_metadata.initialize_metadata;
 const name_to_info = horizon_index.name_to_info;
 
@@ -127,6 +127,12 @@ const parse_schema = (schema_toml) => {
     for (const name in schema.collections) {
       collections.push(Object.assign({ id: name }, schema.collections[name]));
     }
+  }
+
+  // Make sure the 'users' collection is present, as some things depend on
+  // its existence.
+  if (!schema.collections || !schema.collections.users) {
+    collections.push({ id: 'users', indexes: [ ] });
   }
 
   const groups = [ ];
@@ -292,7 +298,9 @@ const runApplyCommand = (options) => {
   }).then(() => {
     // Error if any collections will be removed
     if (!options.update) {
-      return r.db(db).table('hz_collections')('id')
+      return r.db(db).table('hz_collections')
+        .filter((row) => row('id').match('^hz_').not())
+        .getField('id')
         .coerceTo('array')
         .setDifference(schema.collections.map((c) => c.id))
         .run(conn)
@@ -356,12 +364,11 @@ const runApplyCommand = (options) => {
     const promises = [ ];
     for (const c of schema.collections) {
       promises.push(
-        create_collection_reql(db, c.id)
-          .run(conn).then((res) => {
-            if (res.error) {
-              throw new Error(res.error);
-            }
-          }));
+        create_collection(db, c.id, conn).then((res) => {
+          if (res.error) {
+            throw new Error(res.error);
+          }
+        }));
     }
 
     for (const c of obsolete_collections) {
@@ -472,7 +479,9 @@ const runSaveCommand = (options) => {
     return r.db(db).wait({ waitFor: 'ready_for_reads', timeout: 30 }).run(conn);
   }).then(() =>
     r.object('collections',
-             r.db(db).table('hz_collections').coerceTo('array')
+             r.db(db).table('hz_collections')
+               .filter((row) => row('id').match('^hz_').not())
+               .coerceTo('array')
                .map((row) =>
                  row.merge({ indexes: r.db(db).table(row('id')).indexList() })),
              'groups', r.db(db).table('hz_groups').coerceTo('array'))

--- a/cli/test/schema.spec.js
+++ b/cli/test/schema.spec.js
@@ -18,6 +18,8 @@ const project_name = 'schema_test';
 
 const testSchema = `# This is a TOML document
 
+[collections.users]
+
 [collections.test_messages]
 indexes = ["hz_[\\\"datetime\\\"]"]
 

--- a/server/src/metadata/collection.js
+++ b/server/src/metadata/collection.js
@@ -1,65 +1,90 @@
 'use strict';
 
 const error = require('../error');
+const Table = require('./table').Table;
+
+const r = require('rethinkdb');
 
 class Collection {
-  constructor(name, table_id) {
+  constructor(db, name) {
     this.name = name;
+    this.table = r.db(db).table(name); // This is the ReQL Table object
+    this._tables = new Map(); // A Map of Horizon Table objects
+    this._registered = false; // Whether the `hz_collections` table says this collection exists
     this._waiters = [ ];
-    this.table = null; // This is the ReQL Table object
-    this._table = null; // This is the Horizon Table object
   }
 
-  close() {
-    if (this._table) {
-      this._table.close();
-      this._table = null;
-    } else {
-      this._waiters.forEach((w) => w(new Error('collection deleted')));
+  _close() {
+    this._tables.forEach((table) => {
+      table._waiters.forEach((w) => w(new Error('collection deleted')));
+      table._waiters = [ ];
+      table.close();
+    });
+    this._waiters.forEach((w) => w(new Error('collection deleted')));
+    this._waiters = [ ];
+  }
+
+  _update_table(table_id, indexes, conn) {
+    let table = this._tables.get(table_id);
+    if (indexes) {
+      if (!table) {
+        table = new Table(this.table, conn);
+        this._tables.set(table_id, table);
+      }
+      table.update_indexes(indexes, conn);
+      this._waiters.forEach((w) => table.on_ready(w));
       this._waiters = [ ];
+    } else {
+      this._tables.delete(table_id);
+      if (table) {
+        table._waiters.forEach((w) => this.on_ready(w));
+        table._waiters = [ ];
+        table.close();
+      }
     }
   }
 
-  on_ready(done) {
-    if (this._table) {
-      this._table.on_ready(done);
-    } else {
+  _register() {
+    this._registered = true;
+  }
+
+  _unregister() {
+    this._registered = false;
+  }
+
+  _can_be_removed() {
+    return this._tables.size === 0 && !this._registered;
+  }
+
+  _on_ready(done) {
+    if (this._tables.size === 0) {
       this._waiters.push(done);
+    } else {
+      this._get_table().on_ready(done);
     }
   }
 
-  set_table(table) {
-    const old_table = this._table;
-    this.table = null;
-    this._table = null;
-
-    if (old_table) {
-      // Take back any waiters from the old Table
-      old_table._waiters.forEach((done) => this.on_ready(done));
-      old_table._waiters = [ ];
-    }
-
-    if (table) {
-      table.collection = this;
-      this.table = table.table;
-      this._table = table;
-      this._waiters.forEach((done) => this._table.on_ready(done));
-      this._waiters = [ ];
-    }
-  }
-
-  create_index() {
-    if (!this._table) {
+  _get_table() {
+    if (this._tables.size === 0) {
       throw new error.CollectionNotReady(this);
     }
-    return this._table.create_index.apply(this._table, arguments);
+    return this._tables.values().next().value;
   }
 
-  get_matching_index() {
-    if (!this._table) {
-      throw new error.CollectionNotReady(this);
+  _create_index(fields, conn, done) {
+    return this._get_table().create_index(fields, conn, done);
+  }
+
+  get_matching_index(fuzzy_fields, ordered_fields) {
+    const match = this._get_table().get_matching_index(fuzzy_fields, ordered_fields);
+
+    if (match && !match.ready()) {
+      throw new error.IndexNotReady(this, match);
+    } else if (!match) {
+      throw new error.IndexMissing(this, fuzzy_fields.concat(ordered_fields));
     }
-    return this._table.get_matching_index.apply(this._table, arguments);
+
+    return match;
   }
 }
 

--- a/server/src/metadata/collection.js
+++ b/server/src/metadata/collection.js
@@ -52,7 +52,7 @@ class Collection {
     this._registered = false;
   }
 
-  _can_be_removed() {
+  _is_safe_to_remove() {
     return this._tables.size === 0 && !this._registered;
   }
 

--- a/server/src/metadata/metadata.js
+++ b/server/src/metadata/metadata.js
@@ -4,45 +4,36 @@ const error = require('../error');
 const logger = require('../logger');
 const Group = require('../permissions/group').Group;
 const Collection = require('./collection').Collection;
-const Table = require('./table').Table;
 const version_field = require('../endpoint/writes').version_field;
 const utils = require('../utils');
 
 const r = require('rethinkdb');
 
-// These are exported for use by the CLI. They accept 'R' as a parameter because of
-// https://github.com/rethinkdb/rethinkdb/issues/3263
-const create_collection_reql = (db, collection) =>
-  r.db(db).table('hz_collections').get(collection).do((row) =>
+const create_collection = (db, name, conn) =>
+// TODO: if the row was already there, this should appear to be success
+// TODO: majority write to 'hz_collections'
+  r.db(db).table('hz_collections').insert({ id: name }).do((res) =>
     r.branch(
-      row.eq(null),
-      r.db(db).tableCreate(collection).do((create_res) =>
-        r.branch(
-          create_res.hasFields('error'),
-          r.error(create_res('error')),
-          create_res('config_changes')(0)('new_val')('id').do((table_id) =>
-            r.db(db).table('hz_collections').get(collection)
-              .replace((old_row) =>
-                r.branch(
-                  old_row.eq(null),
-                  { id: collection, table_id },
-                  old_row),
-                { returnChanges: 'always' })('changes')(0)
-                  .do((res) =>
-                    r.branch(
-                      r.or(res.hasFields('error'),
-                           res('new_val')('table_id').ne(table_id)),
-                      r.db('rethinkdb').table('table_config').get(table_id).delete().do(() => res),
-                      res))))),
-      { old_val: row, new_val: row }));
+      res('inserted').eq(1),
+      r.db(db).tableCreate(name),
+      res
+    )
+  ).run(conn);
 
 const initialize_metadata = (db, conn) =>
-  r.branch(r.dbList().contains(db), null, r.dbCreate(db)).run(conn).then(() =>
-    Promise.all([ 'hz_collections', 'hz_users_auth', 'hz_groups', 'users' ].map((table) =>
-      r.branch(r.db(db).tableList().contains(table),
-               { },
-               r.db(db).tableCreate(table))
-        .run(conn))));
+  r.branch(r.dbList().contains(db), null, r.dbCreate(db)).run(conn)
+    .then(() =>
+      Promise.all([ 'hz_collections', 'hz_users_auth', 'hz_groups' ].map((table) =>
+        r.branch(r.db(db).tableList().contains(table),
+                 { },
+                 r.db(db).tableCreate(table))
+          .run(conn))))
+    .then(() =>
+      Promise.all([
+        create_collection(db, 'users', conn),
+        r.db(db).table('hz_collections').insert({ id: 'hz_metadata', version: '2.0.0' }).run(conn),
+      ])
+    );
 
 class Metadata {
   constructor(project_name,
@@ -57,7 +48,6 @@ class Metadata {
     this._auto_create_index = auto_create_index;
     this._closed = false;
     this._ready = false;
-    this._tables = new Map();
     this._collections = new Map();
     this._groups = new Map();
     this._collection_feed = null;
@@ -69,7 +59,7 @@ class Metadata {
       return r.db('rethinkdb').table('server_status').nth(0)('process')('version').run(this._conn)
                .then((res) => utils.rethinkdb_version_check(res));
     }).then(() => {
-      logger.debug('checking for internal db/tables');
+      logger.debug('checking for internal tables');
       if (this._auto_create_collection) {
         return initialize_metadata(this._db, this._conn);
       } else {
@@ -128,6 +118,7 @@ class Metadata {
       const collection_changefeed =
         r.db(this._db)
           .table('hz_collections')
+          .filter((row) => row('id').match('^hz_').not())
           .changes({ squash: false,
                      includeInitial: true,
                      includeStates: true,
@@ -148,30 +139,22 @@ class Metadata {
                 } else if (change.type === 'initial' ||
                            change.type === 'add' ||
                            change.type === 'change') {
-                  // Ignore special collections
-                  if (change.new_val.id !== 'users') {
-                    const collection_name = change.new_val.id;
-                    const table_id = change.new_val.table_id;
-                    let collection = this._collections.get(collection_name);
-                    if (!collection) {
-                      collection = new Collection(collection_name, table_id);
-                      this._collections.set(collection_name, collection);
-                    }
-
-                    // Check if we already have a table object for this collection
-                    // TODO: timer-supervise this state - if we don't have a table after x seconds, delete the collection row
-                    const table = this._tables.get(table_id);
-                    if (table) {
-                      collection.set_table(table);
-                    }
+                  const collection_name = change.new_val.id;
+                  let collection = this._collections.get(collection_name);
+                  if (!collection) {
+                    collection = new Collection(this._db, collection_name);
+                    this._collections.set(collection_name, collection);
                   }
+                  collection._register();
                 } else if (change.type === 'uninitial' ||
                            change.type === 'remove') {
-                  // Ignore special collections
-                  if (change.old_val.id !== 'users') {
-                    const collection = this._collections.get(change.old_val.id);
-                    this._collections.delete(change.old_val.id);
-                    collection.close();
+                  const collection = this._collections.get(change.old_val.id);
+                  if (collection) {
+                    collection._unregister();
+                    if (collection._ok_to_remove()) {
+                      this._collections.delete(change.old_val.id);
+                      collection._close();
+                    }
                   }
                 }
               }).catch(reject);
@@ -208,24 +191,25 @@ class Metadata {
                 } else if (change.type === 'initial' ||
                            change.type === 'add' ||
                            change.type === 'change') {
-                  const table_name = change.new_val.name;
+                  const collection_name = change.new_val.name;
                   const table_id = change.new_val.id;
-                  let table = this._tables.get(table_id);
-                  if (!table) {
-                    table = new Table(table_name, table_id, this._db, this._conn);
-                    this._tables.set(table_id, table);
-                  }
-                  table.update_indexes(change.new_val.indexes, this._conn);
 
-                  const collection = this._collections.get(table_name);
-                  if (collection) {
-                    collection.set_table(table);
+                  let collection = this._collections.get(collection_name);
+                  if (!collection) {
+                    collection = new Collection(this._db, collection_name);
+                    this._collections.set(collection_name, collection);
                   }
+                  collection._update_table(table_id, change.new_val.indexes, this._conn);
                 } else if (change.type === 'uninitial' ||
                            change.type === 'remove') {
-                  const table = this._tables.get(change.old_val.id);
-                  this._tables.delete(change.old_val.id);
-                  table.close();
+                  const collection = this._collections.get(change.old_val.name);
+                  if (collection) {
+                    collection._update_table(change.old_val.id, null, this._conn);
+                    if (collection._can_be_removed()) {
+                      this._collections.delete(collection);
+                      collection._close();
+                    }
+                  }
                 }
               }).catch(reject);
             });
@@ -265,23 +249,6 @@ class Metadata {
                      r.error(res('error')),
                      res('new_val'))).run(this._conn),
       ]);
-    }).then(() =>
-      // Get the table_id of the users table
-      r.db('rethinkdb').table('table_config')
-        .filter({ db: this._db, name: 'users' })
-        .nth(0)('id')
-        .run(this._conn)
-    ).then((table_id) => {
-      logger.debug('redirecting users table');
-      // Redirect the 'users' table to the one in the internal db
-      const users_table = new Table('users', table_id, this._db, this._conn);
-      users_table.update_indexes([ ]);
-
-      const users_collection = new Collection({ id: 'users', table: 'users' }, this._internal_db);
-      users_collection.set_table(users_table);
-
-      this._tables.set(table_id, users_table);
-      this._collections.set('users', users_collection);
     }).then(() => {
       logger.debug('metadata sync complete');
       this._ready = true;
@@ -307,11 +274,8 @@ class Metadata {
       this._index_feed.close().catch(() => { });
     }
 
-    this._collections.forEach((x) => x.close());
+    this._collections.forEach((collection) => collection._close());
     this._collections.clear();
-
-    this._tables.forEach((x) => x.close());
-    this._tables.clear();
   }
 
   is_ready() {
@@ -328,32 +292,26 @@ class Metadata {
                       'and cannot be used in requests.');
     }
 
-    const res = this._collections.get(name);
-    if (res === undefined) { throw new error.CollectionMissing(name); }
-    if (res.promise) { throw new error.CollectionNotReady(res); }
-    if (!res._table) { throw new error.CollectionNotReady(res); }
-    return res;
+    const collection = this._collections.get(name);
+    if (collection === undefined) { throw new error.CollectionMissing(name); }
+    if (!collection._get_table().ready()) { throw new error.CollectionNotReady(collection); }
+    return collection;
   }
 
   handle_error(err, done) {
     logger.debug(`Handling error: ${err.message}`);
     try {
-      if (this._auto_create_collection) {
-        if (err instanceof error.CollectionMissing) {
-          logger.warn(`Auto-creating collection: ${err.name}`);
-          return this.create_collection(err.name, done);
-        } else if (err instanceof error.CollectionNotReady) {
-          return err.collection.on_ready(done);
-        }
-      }
-      if (this._auto_create_index) {
-        if (err instanceof error.IndexMissing) {
-          logger.warn(`Auto-creating index on collection "${err.collection.name}": ` +
-                      `${JSON.stringify(err.fields)}`);
-          return err.collection.create_index(err.fields, this._conn, done);
-        } else if (err instanceof error.IndexNotReady) {
-          return err.index.on_ready(done);
-        }
+      if (err instanceof error.CollectionNotReady) {
+        return err.collection._on_ready(done);
+      } else if (err instanceof error.IndexNotReady) {
+        return err.index.on_ready(done);
+      } else if (this._auto_create_collection && (err instanceof error.CollectionMissing)) {
+        logger.warn(`Auto-creating collection: ${err.name}`);
+        return this.create_collection(err.name, done);
+      } else if (this._auto_create_index && (err instanceof error.IndexMissing)) {
+        logger.warn(`Auto-creating index on collection "${err.collection.name}": ` +
+                    `${JSON.stringify(err.fields)}`);
+        return err.collection._create_index(err.fields, this._conn, done);
       }
       done(err);
     } catch (new_err) {
@@ -366,26 +324,20 @@ class Metadata {
     error.check(this._collections.get(name) === undefined,
                 `Collection "${name}" already exists.`);
 
-    // We don't have the collection's table id yet, so pass null down until we get
-    // notified by the index_changefeed about the new table.
-    const collection = new Collection(name, null);
+    const collection = new Collection(this._db, name);
     this._collections.set(name, collection);
 
-    create_collection_reql(this._db, name)
-      .run(this._conn)
-      .then((res) => {
-        error.check(!res.error, `Collection creation failed: "${name}", ${res.error}`);
-        logger.warn(`Collection created: "${name}"`);
-        collection.on_ready(done);
-      }).catch((err) => {
-        // If an error occurred we should clean up this proto-collection - but only if
-        // it hasn't changed yet - e.g. it was created by another instance at the same time.
-        if (collection._table_name === null) {
-          collection.close();
-          this._collections.delete(name);
-        }
-        done(err);
-      });
+    create_collection(this._db, name, this._conn).then((res) => {
+      error.check(!res.error, `Collection "${name}" creation failed: ${res.error}`);
+      logger.warn(`Collection created: "${name}"`);
+      collection._on_ready(done);
+    }).catch((err) => {
+      if (collection._ok_to_remove()) {
+        this._collections.delete(name);
+        collection._close();
+      }
+      done(err);
+    });
   }
 
   get_user_feed(id) {
@@ -403,4 +355,4 @@ class Metadata {
   }
 }
 
-module.exports = { Metadata, create_collection_reql, initialize_metadata };
+module.exports = { Metadata, create_collection, initialize_metadata };

--- a/server/src/metadata/table.js
+++ b/server/src/metadata/table.js
@@ -7,9 +7,8 @@ const logger = require('../logger');
 const r = require('rethinkdb');
 
 class Table {
-  constructor(table, table_id, db, conn) {
-    this.collection = null; // This will be set when we are attached to a collection
-    this.table = r.db(db).table(table);
+  constructor(reql_table, conn) {
+    this.table = reql_table;
     this.indexes = new Map();
 
     this._waiters = [ ];
@@ -87,7 +86,7 @@ class Table {
       // Create the Index object now so we don't try to create it again before the
       // feed notifies us of the index creation
       const new_index = new index.Index(index_name, this.table, conn);
-      this.indexes.set(index_name, new_index);
+      this.indexes.set(index_name, new_index); // TODO: shouldn't this be done before we go async?
       return new_index.on_ready(done);
     };
 
@@ -122,11 +121,7 @@ class Table {
       }
     }
 
-    if (match) {
-      throw new error.IndexNotReady(this.collection, match);
-    } else {
-      throw new error.IndexMissing(this.collection, fuzzy_fields.concat(ordered_fields));
-    }
+    return match;
   }
 }
 


### PR DESCRIPTION
@danielmewes brought up that a user restoring from a backup would have an unusable horizon database because the tables would have different UUIDs that what was stored in `hz_collections`.  In order to avoid this, we are dropping UUIDs from the `hz_collections` table, and modifying the creation process to:
- attempt to insert in the `hz_collections` table
- if the insert was successful, create the table

With this process, we should never have a name conflict barring certain (rather obscure) cases, but if one does happen, we will be unable to serve those collections until an operator intervenes.

This branch also addresses issue #708.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/730)

<!-- Reviewable:end -->
