### PR TITLE
Modify schema index format

### DIFF
--- a/cli/src/schema.js
+++ b/cli/src/schema.js
@@ -21,7 +21,6 @@ const toml = require('toml');
 const r = horizon_server.r;
 const create_collection_reql = horizon_metadata.create_collection_reql;
 const initialize_metadata = horizon_metadata.initialize_metadata;
-const name_to_info = horizon_index.name_to_info;
 
 initialize_joi(Joi);
 
@@ -99,9 +98,16 @@ const parseArguments = (args) => {
 const schema_schema = Joi.object().unknown(false).keys({
   collections: Joi.object().unknown(true).pattern(/.*/,
     Joi.object().unknown(false).keys({
-      indexes: Joi.array().items(Joi.string().min(1)).default([ ]),
+      indexes: Joi.array().items(
+        Joi.alternatives(
+          Joi.string(),
+          Joi.object().unknown(false).keys({
+            fields: Joi.array().items(Joi.array().items(Joi.string())).required(),
+          })
+        )
+      ).optional().default([ ]),
     })
-  ).optional(),
+  ).optional().default({ }),
   groups: Joi.object().unknown(true).pattern(/.*/,
     Joi.object().keys({
       rules: Joi.object().unknown(true).pattern(/.*/,
@@ -111,8 +117,36 @@ const schema_schema = Joi.object().unknown(false).keys({
         })
       ).optional().default({ }),
     })
-  ).optional(),
+  ).optional().default({ }),
 });
+
+// Preserved for interpreting old schemas
+const v1_0_name_to_fields = (name) => {
+  let escaped = false;
+  let field = '';
+  const fields = [ ];
+  for (const c of name) {
+    if (escaped) {
+      if (c !== '\\' && c !== '_') {
+        throw new Error(`Unexpected index name: "${name}"`);
+      }
+      escaped = false;
+      field += c;
+    } else if (c === '\\') {
+      escaped = true;
+    } else if (c === '_') {
+      fields.push(field);
+      field = '';
+    } else {
+      field += c;
+    }
+  }
+  if (escaped) {
+    throw new Error(`Unexpected index name: "${name}"`);
+  }
+  fields.push([ field ]);
+  return fields;
+};
 
 const parse_schema = (schema_toml) => {
   const parsed = Joi.validate(toml.parse(schema_toml), schema_schema);
@@ -123,17 +157,22 @@ const parse_schema = (schema_toml) => {
   }
 
   const collections = [ ];
-  if (schema.collections) {
-    for (const name in schema.collections) {
-      collections.push(Object.assign({ id: name }, schema.collections[name]));
-    }
+  for (const name in schema.collections) {
+    collections.push({
+      id: name,
+      indexes: schema.collections[name].indexes.map((index) => {
+        if (typeof index === 'string') {
+          return { fields: v1_0_name_to_fields(index), multi: false, geo: false };
+        } else {
+          return { fields: index.fields, multi: false, geo: false };
+        }
+      }),
+    });
   }
 
   const groups = [ ];
-  if (schema.groups) {
-    for (const name in schema.groups) {
-      groups.push(Object.assign({ id: name }, schema.groups[name]));
-    }
+  for (const name in schema.groups) {
+    groups.push(Object.assign({ id: name }, schema.groups[name]));
   }
 
   return { groups, collections };
@@ -211,9 +250,11 @@ const schema_to_toml = (collections, groups) => {
   for (const c of collections) {
     res.push('');
     res.push(`[collections.${c.id}]`);
-    if (c.indexes.length > 0) {
-      res.push(`indexes = ${JSON.stringify(c.indexes)}`);
-    }
+    c.indexes.forEach((index) => {
+      const info = horizon_index.name_to_info(index);
+      res.push(`[[collections.${c.id}.indexes]]`);
+      res.push(`fields = ${JSON.stringify(info.fields)}`);
+    });
   }
 
   for (const g of groups) {
@@ -387,50 +428,40 @@ const runApplyCommand = (options) => {
   }).then(() => {
     const promises = [ ];
 
-    // Determine the index fields of each index from the name
+    // Ensure all indexes exist
     for (const c of schema.collections) {
-      c.index_fields = { };
-      for (const index of c.indexes) {
-        c.index_fields[index] = name_to_info(index).fields;
+      for (const info of c.indexes) {
+        const name = horizon_index.info_to_name(info);
+        promises.push(
+          r.branch(r.db(db).table(c.id).indexList().contains(name), { },
+                   r.db(db).table(c.id).indexCreate(name, horizon_index.info_to_reql(info),
+                     { geo: Boolean(info.geo), multi: (info.multi !== false) }))
+            .run(conn)
+            .then((res) => {
+              if (res.errors) {
+                throw new Error(`Failed to create index ${name} ` +
+                                `on collection ${c.id}: ${res.first_error}`);
+              }
+            }));
       }
     }
 
-    // Ensure all indexes exist
-    promises.push(
-      r.expr(schema.collections)
-        .forEach((c) =>
-          r.db(db).table('hz_collections').get(c('id')).do((collection) =>
-            // TODO: disambiguate using 'table' field once ReQL supports it
-            c('indexes')
-              .setDifference(r.db(db).table(collection('id')).indexList())
-              .forEach((index) =>
-                c('index_fields')(index).do((fields) =>
-                  r.db(db).table(collection('id')).indexCreate(index, (row) =>
-                    fields.map((key) => row(key)))))))
-        .run(conn)
-        .then((res) => {
-          if (res.errors) {
-            throw new Error(`Failed to create indexes: ${res.first_error}`);
-          }
-        }));
-
     // Remove obsolete indexes
     if (!options.update) {
-      promises.push(
-        r.expr(schema.collections)
-          .forEach((c) =>
-            r.db(db).table('hz_collections').get(c('id')).do((collection) =>
-              // TODO: disambiguate using 'table' field once ReQL supports it
-              r.db(db).table(collection('id')).indexList()
-                .setDifference(c('indexes'))
-                .forEach((index) =>
-                  r.db(db).table(collection('id')).indexDrop(index))))
-        .run(conn)
-        .then((res) => {
-          if (res.errors) {
-            throw new Error(`Failed to remove old indexes: ${res.first_error}`);
-          }
-        }));
+      for (const c of schema.collections) {
+        const names = c.indexes.map(horizon_index.info_to_name);
+        promises.push(
+          r.db(db).table(c.id).indexList().filter((name) => name.match('^hz_'))
+            .setDifference(names)
+            .forEach((name) => r.db(db).table(c.id).indexDrop(name))
+            .run(conn)
+            .then((res) => {
+              if (res.errors) {
+                throw new Error('Failed to remove old indexes ' +
+                                `on collection ${c.id}: ${res.first_error}`);
+              }
+            }));
+      }
     }
 
     return Promise.all(promises);

--- a/cli/test/schema.spec.js
+++ b/cli/test/schema.spec.js
@@ -80,7 +80,7 @@ describe('hz schema', () => {
 
   describe('save', () => {
     before('initialize database', () => {
-      mockFs(valid_file_system);
+      fs_with_schema(v2_schema);
       return runApplyCommand(processApplyConfig({
         start_rethinkdb: false,
         schema_file: '.hz/schema.toml',

--- a/cli/test/schema.spec.js
+++ b/cli/test/schema.spec.js
@@ -16,10 +16,22 @@ const tmpdir = require('os').tmpdir;
 
 const project_name = 'schema_test';
 
-const testSchema = `# This is a TOML document
+const v1_schema = ` 
+[collections.test_messages]
+indexes = ["datetime"]
+
+[groups.admin]
+[groups.admin.rules.carte_blanche]
+template = "any()"
+`;
+
+const v2_schema = `# This is a TOML document
 
 [collections.test_messages]
-indexes = ["hz_[\\\"datetime\\\"]"]
+[[collections.test_messages.indexes]]
+fields = [["a","b"],["c"]]
+[[collections.test_messages.indexes]]
+fields = [["datetime"]]
 
 [groups.admin]
 [groups.admin.rules.carte_blanche]
@@ -35,10 +47,8 @@ indexes = ["datetime"]
 template = "any()a;lkdfjlakjf;ladkfjal;kfj"
 `;
 
-const valid_file_system = {
-  '.hz': {
-    'schema.toml': testSchema,
-  },
+const fs_with_schema = (schema) => {
+  mockFs({ '.hz': { 'schema.toml': schema } });
 };
 
 describe('hz schema', () => {
@@ -63,7 +73,7 @@ describe('hz schema', () => {
     })
   );
 
-  beforeEach('initialize mockfs', () => mockFs(valid_file_system));
+  beforeEach('initialize mockfs', () => fs_with_schema(v2_schema));
   afterEach('restore fs', () => mockFs.restore());
 
   describe('save', () => {
@@ -92,13 +102,22 @@ describe('hz schema', () => {
         out_file: fs.createWriteStream('out.toml', { flags: 'w' }),
         project_name,
       }).then(() =>
-        assert.strictEqual(fs.readFileSync('out.toml', 'utf8'), testSchema)
+        assert.strictEqual(fs.readFileSync('out.toml', 'utf8'), v2_schema)
       )
     );
   });
 
   describe('apply', () => {
-    it('should apply schema to rdb from schema.toml', () => {
+    afterEach('clear database', () =>
+      r.branch(
+        r.dbList().contains(project_name),
+        r.dbDrop(project_name),
+        null
+      ).run(rdb_conn)
+    );
+
+    it('applies v1.x schema to rdb from schema.toml', () => {
+      fs_with_schema(v1_schema);
       const config = processApplyConfig({
         connect: `localhost:${rdb_server.driver_port}`,
         schema_file: '.hz/schema.toml',
@@ -117,19 +136,48 @@ describe('hz schema', () => {
       ).then((res) =>
         assert(res, `${project_name} database is missing.`)
       ).then(() =>
+        r.db(project_name).table('test_messages').indexList().run(rdb_conn)
+      ).then((indexes) => {
         // Check that the expected indexes exist on the expected table
-        r.db(project_name).table('test_messages')
-          .indexList().contains('hz_["datetime"]')
-          .run(rdb_conn)
+        assert(indexes.indexOf('hz_[["datetime"]]') !== -1, '"datetime" index is missing');
+      });
+    });
+
+    it('applies v2.x schema to rdb from schema.toml', () => {
+      const config = processApplyConfig({
+        connect: `localhost:${rdb_server.driver_port}`,
+        schema_file: '.hz/schema.toml',
+        start_rethinkdb: false,
+        update: true,
+        force: true,
+        secure: false,
+        permissions: false,
+        project_name,
+      });
+
+      // Apply settings into RethinkDB
+      return runApplyCommand(config).then(() =>
+        // Check that the project database exists
+        r.dbList().contains(project_name).run(rdb_conn)
       ).then((res) =>
-        assert(res, '"datetime" index is missing')
-      );
+        assert(res, `${project_name} database is missing.`)
+      ).then(() =>
+        r.db(project_name).table('test_messages').indexList().run(rdb_conn)
+      ).then((indexes) => {
+        // Check that the expected indexes exist on the expected table
+        assert(indexes.indexOf('hz_[["datetime"]]') !== -1, '"datetime" index is missing');
+        assert(indexes.indexOf('hz_[["a","b"],["c"]]') !== -1, '[["a","b"],["c"]] index is missing');
+      });
     });
   });
 
   describe('given a schema.toml file', () => {
-    it('can parse a valid schema.toml file', () => {
-      parse_schema(testSchema);
+    it('can parse a valid v1.x schema.toml file', () => {
+      parse_schema(v1_schema);
+    });
+
+    it('can parse a valid v2.x schema.toml file', () => {
+      parse_schema(v2_schema);
     });
 
     it('fails parsing invalid schema.toml file', () => {

--- a/server/src/endpoint/query.js
+++ b/server/src/endpoint/query.js
@@ -7,6 +7,16 @@ const reql_options = require('./common').reql_options;
 const Joi = require('joi');
 const r = require('rethinkdb');
 
+const object_to_fields = (obj) =>
+  Object.keys(obj).map((key) => {
+    const value = obj[key];
+    if (value !== null && typeof value === 'object') {
+      return object_to_fields(value).map((subkeys) => [ key ].concat(subkeys));
+    } else {
+      return [ key ];
+    }
+  });
+
 // This is exposed to be reused by 'subscribe'
 const make_reql = (raw_request, metadata) => {
   const parsed = Joi.validate(raw_request.options, query);
@@ -17,6 +27,7 @@ const make_reql = (raw_request, metadata) => {
   let reql = collection.table;
 
   const ordered_between = (obj) => {
+    const fuzzy_fields = object_to_fields(obj);
     const order_keys = (options.order && options.order[0]) ||
                        (options.above && Object.keys(options.above[0])) ||
                        (options.below && Object.keys(options.below[0])) || [ ];
@@ -26,7 +37,7 @@ const make_reql = (raw_request, metadata) => {
       check(!options.above || options.above[0][k] !== undefined,
             '"above" must be on the same field as the first in "order".');
       check(!options.below || options.below[0][k] !== undefined,
-            '"below" must be on the same field as the first in "order"');
+            '"below" must be on the same field as the first in "order".');
     }
 
     order_keys.forEach((k) => {
@@ -34,7 +45,7 @@ const make_reql = (raw_request, metadata) => {
             `"${k}" cannot be used in "order", "above", or "below" when finding by that field.`);
     });
 
-    const index = collection.get_matching_index(Object.keys(obj), order_keys);
+    const index = collection.get_matching_index(fuzzy_fields, order_keys.map((k) => [ k ]));
 
     const get_bound = (name) => {
       const eval_key = (key) => {

--- a/server/src/endpoint/query.js
+++ b/server/src/endpoint/query.js
@@ -10,7 +10,7 @@ const r = require('rethinkdb');
 const object_to_fields = (obj) =>
   Object.keys(obj).map((key) => {
     const value = obj[key];
-    if (value !== null && typeof value === 'object') {
+    if (value !== null && typeof value === 'object' && !value['$reql_type$']) {
       return object_to_fields(value).map((subkeys) => [ key ].concat(subkeys));
     } else {
       return [ key ];

--- a/server/src/metadata/collection.js
+++ b/server/src/metadata/collection.js
@@ -3,7 +3,7 @@
 const error = require('../error');
 
 class Collection {
-  constructor(name, table_id) {
+  constructor(name) {
     this.name = name;
     this._waiters = [ ];
     this.table = null; // This is the ReQL Table object

--- a/server/src/metadata/index.js
+++ b/server/src/metadata/index.js
@@ -37,18 +37,14 @@ const name_to_info = (name) => {
 
   // Sanity check fields
   const validate_field = (f) => {
-    if (Array.isArray(f)) {
-      f.forEach((s) => check(typeof s === 'string',
-                             `Unexpected index name (invalid field): "${name}"`));
-    } else {
-      check(typeof f === 'string',
-            `Unexpected index name (field is not a string or array): "${name}"`);
-    }
+    check(Array.isArray(f), `Unexpected index name (invalid field): "${name}"`);
+    f.forEach((s) => check(typeof s === 'string',
+                           `Unexpected index name (invalid field): "${name}"`));
   };
 
   check(Array.isArray(info.fields),
         `Unexpected index name (fields are not an array): "${name}"`);
-  check((info.multi === null) || info.multi < info.fields.length,
+  check((info.multi === false) || (info.multi < info.fields.length),
         `Unexpected index name (multi index out of bounds): "${name}"`);
   info.fields.forEach(validate_field);
   return info;
@@ -59,11 +55,50 @@ const info_to_name = (info) => {
   if (info.geo) {
     res += 'geo_';
   }
-  if (info.multi !== null) {
+  if (info.multi !== false) {
     res += 'multi_' + info.multi + '_';
   }
   res += JSON.stringify(info.fields);
   return res;
+};
+
+const info_to_reql = (info) => {
+  if (info.geo && (info.multi !== false)) {
+    throw new Error('multi and geo cannot be specified on the same index');
+  }
+
+  if (info.multi !== false) {
+    const multi_field = info.fields[info.multi];
+    return (row) =>
+      row(multi_field).map((value) => info.fields.map((f, i) => {
+        if (i === info.multi) {
+          return value;
+        } else {
+          let res = row;
+          f.forEach((field_name) => { res = res(field_name); });
+          return res;
+        }
+      }));
+  } else {
+    return (row) =>
+      info.fields.map((f) => {
+        let res = row;
+        f.forEach((field_name) => { res = res(field_name); });
+        return res;
+      });
+  }
+};
+
+const compare_fields = (a, b) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
 };
 
 class Index {
@@ -136,17 +171,20 @@ class Index {
     }
 
     for (let i = 0; i < fuzzy_fields.length; ++i) {
-      const pos = this.fields.indexOf(fuzzy_fields[i]);
-      if (pos < 0 || pos >= fuzzy_fields.length) { return false; }
+      let found = false;
+      for (let j = 0; j < fuzzy_fields.length && !found; ++j) {
+        found = compare_fields(fuzzy_fields[i], this.fields[j]);
+      }
+      if (!found) { return false; }
     }
 
     for (let i = 0; i < ordered_fields.length; ++i) {
       const pos = this.fields.length - ordered_fields.length + i;
-      if (pos < 0 || this.fields[pos] !== ordered_fields[i]) { return false; }
+      if (pos < 0 || !compare_fields(ordered_fields[i], this.fields[pos])) { return false; }
     }
 
     return true;
   }
 }
 
-module.exports = { Index, primary_index_name, name_to_info, info_to_name };
+module.exports = { Index, primary_index_name, name_to_info, info_to_name, info_to_reql };

--- a/server/src/metadata/index.js
+++ b/server/src/metadata/index.js
@@ -166,7 +166,9 @@ class Index {
       return false;
     }
 
-    if (this.fields.length > fuzzy_fields.length + ordered_fields.length) {
+    if (this.fields.length > fuzzy_fields.length + ordered_fields.length ||
+        this.fields.length < fuzzy_fields.length ||
+        this.fields.length < ordered_fields.length) {
       return false;
     }
 

--- a/server/src/metadata/table.js
+++ b/server/src/metadata/table.js
@@ -80,7 +80,8 @@ class Table {
 
   // TODO: support geo and multi indexes
   create_index(fields, conn, done) {
-    const index_name = index.info_to_name({ geo: false, multi: null, fields });
+    const info = { geo: false, multi: false, fields };
+    const index_name = index.info_to_name(info);
     error.check(!this.indexes.get(index_name), 'index already exists');
 
     const success = () => {
@@ -91,7 +92,8 @@ class Table {
       return new_index.on_ready(done);
     };
 
-    this.table.indexCreate(index_name, (row) => fields.map((key) => row(key)))
+    this.table.indexCreate(index_name, index.info_to_reql(info),
+                           { geo: info.geo, multi: (info.multi !== false) })
       .run(conn)
       .then(success)
       .catch((err) => {


### PR DESCRIPTION
Addresses #706.  Also fixes a problem with non-nested fields.  Specifically, TOML cannot generate an array with disparate types (i.e. strings for fields and arrays for nested fields for a given index).  Therefore, the index fields format is now unified so that is it always an array of arrays.  This is probably better as it ensures there is exactly one format for an index name (barring whitespace concerns).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/732)

<!-- Reviewable:end -->
