### PR TITLE
fixed auth0 auth to work like a normal oauth2 provider

### DIFF
--- a/cli/src/utils/config.js
+++ b/cli/src/utils/config.js
@@ -189,15 +189,10 @@ const read_from_env = () => {
       } else if (varPath[0] === 'auth') {
         if (varPath.length !== 3) {
           console.log(`Ignoring malformed Horizon environment variable: "${env_var}", ` +
-                      'should be HZ_AUTH_{PROVIDER}_ID or HZ_AUTH_{PROVIDER}_SECRET.');
+                      'should be HZ_AUTH_{PROVIDER}_{OPTION}.');
         } else {
           config.auth[varPath[1]] = config.auth[varPath[1]] || { };
-
-          if (varPath[2] === 'id') {
-            config.auth[varPath[1]].id = value;
-          } else if (varPath[2] === 'secret') {
-            config.auth[varPath[1]].secret = value;
-          }
+          config.auth[varPath[1]][varPath[2]] = value;
         }
       } else if (yes_no_options.indexOf(destVarName) !== -1) {
         config[destVarName] = parse_yes_no_option(value, destVarName);

--- a/server/src/auth/auth0.js
+++ b/server/src/auth/auth0.js
@@ -4,8 +4,10 @@ const auth_utils = require('./utils');
 const logger = require('../logger');
 
 const https = require('https');
-const Joi = require('joi');
+const querystring = require('querystring');
 const url = require('url');
+
+const Joi = require('joi');
 
 const options_schema = Joi.object().keys({
   path: Joi.string().required(),
@@ -16,11 +18,8 @@ const options_schema = Joi.object().keys({
 
 function auth0(horizon, raw_options) {
   const options = Joi.attempt(raw_options, options_schema);
-  const response_type = 'token';
   const client_id = options.id;
   const client_secret = options.secret;
-  const provider = options.path;
-  const return_url = horizon._auth._success_redirect.href.slice(0, -1);
   const host = options.host;
 
   const self_url = (self_host, path) =>
@@ -30,76 +29,32 @@ function auth0(horizon, raw_options) {
     url.format({ protocol: 'https',
                  host: host,
                  pathname: '/authorize',
-                 query: { response_type, client_id, redirect_uri, state } });
+                 query: { response_type: 'code', client_id, redirect_uri, state } });
+
+  const make_token_request = (code, redirect_uri) => {
+    const req = https.request({ method: 'POST', host, path: '/oauth/token',
+                                headers: { 'Content-type': 'application/x-www-form-urlencoded' } });
+    req.write(querystring.stringify({
+        client_id, redirect_uri, client_secret, code,
+        grant_type: 'authorization_code'
+      }));
+    return req;
+  };
 
   const make_inspect_request = (access_token) =>
-    https.request({ host: host,
-                    path: '/userinfo',
+    https.request({ host, path: '/userinfo',
                     headers: { Authorization: `Bearer ${access_token}` } });
 
   const extract_id = (user_info) => user_info && user_info.identities[0].user_id;
 
-  const make_success_url = (horizon_token) =>
-    url.format(auth_utils.extend_url_query(horizon._auth._success_redirect, { horizon_token }));
 
-  const make_failure_url = (horizon_error) =>
-    url.format(auth_utils.extend_url_query(horizon._auth._failure_redirect, { horizon_error }));
-
-  horizon.add_http_handler(provider, (req, res) => {
-    const request_url = url.parse(req.url, true);
-    const access_token = request_url.query && request_url.query.access_token;
-    const error = request_url.query && request_url.query.error;
-
-    logger.debug(`oauth request: ${JSON.stringify(request_url)}`);
-    if (error) {
-      const description = request_url.query.error_description || error;
-      auth_utils.do_redirect(res, make_failure_url(description));
-    } else if (!access_token) {
-      // We need to redirect to the API to acquire a token, then come back and try again
-      // Generate a nonce to track this client session to prevent CSRF attacks
-      auth_utils.make_nonce((nonce_err, nonce) => {
-        if (nonce_err) {
-          logger.error(`Error creating nonce for oauth state: ${nonce_err}`);
-          res.statusCode = 503;
-          res.end('error generating nonce');
-        } else {
-          auth_utils.set_nonce(res, horizon._name, nonce);
-          auth_utils.do_redirect(res, make_acquire_url(auth_utils.nonce_to_state(nonce), return_url));
-        }
-      });
-    } else {
-      // Make sure this is the same client who obtained the code to prevent CSRF attacks
-      const nonce = auth_utils.get_nonce(req, horizon._name);
-      const state = request_url.query.state;
-
-      if (!nonce || !state || state !== auth_utils.nonce_to_state(nonce)) {
-        auth_utils.do_redirect(res, make_failure_url('session expired'));
-      } else {
-        // We have the user access token, get info on it so we can find the user
-        auth_utils.run_request(make_inspect_request(access_token), (err2, inner_body) => {
-          const user_info = auth_utils.try_json_parse(inner_body);
-          const user_id = user_info && extract_id(user_info);
-
-          if (err2) {
-            logger.error(`Error contacting oauth API: ${err2}`);
-            res.statusCode = 503;
-            res.end('oauth provider error');
-          } else if (!user_id) {
-            logger.error(`Bad JSON data from oauth API: ${inner_body}`);
-            res.statusCode = 500;
-            res.end('unparseable inspect response');
-          } else {
-            horizon._auth.generate(provider, user_id).nodeify((err3, jwt) => {
-              // Clear the nonce just so we aren't polluting clients' cookies
-              auth_utils.clear_nonce(res, horizon._name);
-              auth_utils.do_redirect(res, err3 ?
-                make_failure_url('invalid user') :
-                make_success_url(jwt.token));
-            });
-          }
-        });
-      }
-    }
+  auth_utils.oauth2({
+    horizon,
+    provider: options.path,
+    make_acquire_url,
+    make_token_request,
+    make_inspect_request,
+    extract_id,
   });
 }
 

--- a/server/src/auth/twitch.js
+++ b/server/src/auth/twitch.js
@@ -33,7 +33,7 @@ function twitch(horizon, raw_options) {
                                 host: 'api.twitch.tv',
                                 path: '/kraken/oauth2/token' });
     req.write(querystring.stringify({
-      code, client_id, client_secret, redirect_uri,
+      client_id, redirect_uri, client_secret, code,
       grant_type: 'authorization_code' }));
     return req;
   };


### PR DESCRIPTION
Turns out it was bypassing the whole horizon server users stuff, so the token wouldn't even be usable for authenticating with horizon.  Auth0 provides a standard oauth2 flow, so just reused the utils for that.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/733)

<!-- Reviewable:end -->
