### PR TITLE
keepalive fix

### DIFF
--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -85,7 +85,7 @@ export class HorizonSocket extends WebSocketSubject {
 
     this.keepalive = Observable
       .timer(keepalive * 1000, keepalive * 1000)
-      .map(n => this.multiplex({ type: 'keepalive', n }))
+      .map(n => this.makeRequest({ type: 'keepalive' }).subscribe())
       .publish()
 
     // This is used to emit status changes that others can hook into.

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -85,7 +85,7 @@ export class HorizonSocket extends WebSocketSubject {
 
     this.keepalive = Observable
       .timer(keepalive * 1000, keepalive * 1000)
-      .map(n => this._multiplex({ type: 'keepalive', n }))
+      .map(n => this.multiplex({ type: 'keepalive', n }))
       .publish()
 
     // This is used to emit status changes that others can hook into.

--- a/server/src/schema/horizon_protocol.js
+++ b/server/src/schema/horizon_protocol.js
@@ -59,7 +59,8 @@ const request = Joi.object({
   request_id: Joi.number().required(),
   type: Joi.string().required(),
   options: Joi.object().required()
-    .when('type', { is: Joi.string().only('end_subscription'), then: Joi.forbidden() }),
+    .when('type', { is: Joi.string().only('end_subscription'), then: Joi.forbidden() })
+    .when('type', { is: Joi.string().only('keepalive'), then: Joi.forbidden() }),
 }).unknown(false);
 
 module.exports = {


### PR DESCRIPTION
1. Modifies socket keepalive to `makeRequest` keepalive message objects.
2. Update request schema to obviate `options` for keepalive message objects.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/743)

<!-- Reviewable:end -->
