### PR TITLE
Set log level on server construction

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -320,15 +320,14 @@ const start_horizon_server = (http_servers, opts) =>
     rdb_user: opts.rdb_user || null,
     rdb_password: opts.rdb_password || null,
     rdb_timeout: opts.rdb_timeout || null,
+    log_level: opts.log_level
   });
 
 // `interruptor` is meant for use by tests to stop the server without relying on SIGINT
 const run = (args, interruptor) => {
   let opts, http_servers, hz_server, rdb_server;
-  const old_log_level = logger.level;
 
   const cleanup = () => {
-    logger.level = old_log_level;
 
     return Promise.all([
       hz_server ? hz_server.close() : Promise.resolve(),
@@ -342,7 +341,7 @@ const run = (args, interruptor) => {
 
   return Promise.resolve().then(() => {
     opts = processConfig(parseArguments(args));
-    logger.level = opts.debug ? 'debug' : 'warn';
+    opts.log_level = opts.debug ? 'debug' : 'warn';
 
     if (!opts.secure && opts.auth && Array.from(Object.keys(opts.auth)).length > 0) {
       logger.warn('Authentication requires that the server be accessible via HTTPS. ' +

--- a/server/src/schema/server_options.js
+++ b/server/src/schema/server_options.js
@@ -20,6 +20,7 @@ const server = Joi.object({
   rdb_user: Joi.string().allow(null),
   rdb_password: Joi.string().allow(null),
   rdb_timeout: Joi.number().allow(null),
+  log_level: Joi.string().default('warn')
 }).unknown(false);
 
 const auth = Joi.object({

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -78,6 +78,7 @@ class Server {
     this._interruptor = new Promise((resolve, reject) => {
       this._interrupt = reject;
     });
+    logger.level = opts.log_level;
 
     try {
       this._reql_conn = new ReqlConnection(opts.rdb_host,


### PR DESCRIPTION
This PR allows to change the log level for embedded horizon.

This is not yet tested. Wanted to get feedback first. If this approach is OK. I will run some additional tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/746)

<!-- Reviewable:end -->
