### PR TITLE
React Native Packager Compatibility Tip

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -56,3 +56,7 @@ Sometimes you may wish to delete all authentication tokens from localStorage. Yo
 // Note the 'H'
 Horizon.clearAuthTokens()
 ```
+
+## Working with React Native
+
+React Native's packager will balk at the current `package.json` babel settings. The default settings in React Native will work perfectly fine for packaging the client library, so to make the packager work, simply remove the `babel` section in `package.json`. (You can do this by simply appending a underscore to the babel key).


### PR DESCRIPTION
Relevant to client 2.0.0-beta-4

Right now Horizon client is broken for React Native straight out of the box (through NPM). React Native tries to package all of a project's dependencies with its own packager. The packager checks all packages for babel configs and will try to use the package's babel config to pack the files properly. However, something seems to be wrong with it trying to use `es2015-loose`. The best workaround I found so far is to just remove the babel configs so that way React Native will try to package it with its own default settings (which works out well). I'm submitting this PR so that anyone else trying to work with RN on horizon v2 beta can at least start experimenting.

It's extremely hacky, if there's something is in the works to fix this permanently that would be great. Would also be awesome if someone else could validate this indeed fixes it and isn't some weird coincidence. Perhaps it would be also good to note that the current stable is _not_ compatible with RN.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/750)

<!-- Reviewable:end -->
