### PR TITLE
fix: don't eagerly create handshake

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -33,7 +33,7 @@ function Horizon({
   const url = `ws${secure ? 's' : ''}:\/\/${host}\/${path}`
   const socket = new HorizonSocket({
     url,
-    handshakeMessage: tokenStorage.handshake(),
+    handshakeMaker: tokenStorage.handshake.bind(tokenStorage),
     keepalive,
     WebSocketCtor,
   })

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -56,7 +56,7 @@ export class HorizonSocket extends WebSocketSubject {
 
   constructor({
     url,              // Full url to connect to
-    handshakeMessage, // function that returns handshake to emit
+    handshakeMaker, // function that returns handshake to emit
     keepalive = 60,   // seconds between keepalive messages
     WebSocketCtor = WebSocket,    // optionally provide a WebSocket constructor
   } = {}) {
@@ -80,7 +80,7 @@ export class HorizonSocket extends WebSocketSubject {
     // Completes or errors based on handshake success. Buffers
     // handshake response for later subscribers (like a Promise)
     this.handshake = new AsyncSubject()
-    this._handshakeMsg = handshakeMessage
+    this._handshakeMaker = handshakeMaker
     this._handshakeSub = null
 
     this.keepalive = Observable
@@ -131,7 +131,7 @@ export class HorizonSocket extends WebSocketSubject {
   // and cleans up after it when the handshake is cleaned up.
   sendHandshake() {
     if (!this._handshakeSub) {
-      this._handshakeSub = this.makeRequest(this._handshakeMsg)
+      this._handshakeSub = this.makeRequest(this._handshakeMaker())
         .subscribe({
           next: n => {
             this.status.next(STATUS_READY)


### PR DESCRIPTION
fixes #663 

Issue was that we eagerly constructed the handshake in the Horizon constructor, which was an error since we don't know if we have a token yet. Now we defer until the time when an actual connection to the server is required.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/752)

<!-- Reviewable:end -->
