### PR TITLE
hz migrate cleanups

### DIFF
--- a/cli/src/main.js
+++ b/cli/src/main.js
@@ -63,13 +63,15 @@ if (!command) {
 
 const done = (err) => {
   if (err) {
-    console.error(chalk.red.bold(
-      `${cmdName} failed ` +
-      `with ${err.stack}`));
+    console.error(chalk.red.bold(err.message));
     process.exit(1);
   } else {
     process.exit(0);
   }
 };
 
-command.run(cmdArgs).then(() => done()).catch(done);
+try {
+  command.run(cmdArgs).then(() => done()).catch(done);
+} catch(err) {
+  done(err)
+}

--- a/cli/src/main.js
+++ b/cli/src/main.js
@@ -72,6 +72,6 @@ const done = (err) => {
 
 try {
   command.run(cmdArgs).then(() => done()).catch(done);
-} catch(err) {
-  done(err)
+} catch (err) {
+  done(err);
 }

--- a/cli/src/migrate.js
+++ b/cli/src/migrate.js
@@ -116,7 +116,10 @@ function processConfig(cmdArgs) {
   }
 
   if (options.project_name == null) {
-    throw new Error('No project_name given');
+    throw new Error(
+      'No project_name given: either pass the --project-name ' +
+        'option or add the "project_name" key to your ' +
+        '.hz/config.toml');
   }
   return options;
 }
@@ -199,9 +202,10 @@ function validateMigration() {
       .run(this.conn)
       .then(() => green(' └── Pre-2.0 schema found'))
       .catch((e) => {
-        throw new Error(
-          `v1.x schema not found (${e.msg}). ` +
-            'Have you already migrated?');
+        throw new Error(`\
+${e.msg}.
+This could happen if you don't have a Horizon app in this database \
+or if you've already migrated to the version 2.0 format.`);
       });
   });
 }
@@ -351,8 +355,9 @@ function rewriteHzCollectionDocs() {
 function exportNewSchema() {
   // Import and run schema save process, giving it a different
   // filename than schema.toml
+  const timestamp = new Date().toISOString().replace(/:/g, '_');
   return accessAsync('.hz/schema.toml', fs.R_OK | fs.F_OK)
-    .then(() => `.hz/schema.toml.migrated.${new Date()}`)
+    .then(() => `.hz/schema.toml.migrated.${timestamp}`)
     .catch(() => '.hz/schema.toml') // if no schema.toml
     .then((schemaFile) => {
       white(`Exporting the new schema to ${schemaFile}`);

--- a/cli/src/utils/config.js
+++ b/cli/src/utils/config.js
@@ -107,7 +107,7 @@ const parse_connect = (connect, config) => {
 const read_from_config_file = (project_path, config_file) => {
   const config = { auth: { } };
 
-  let fileData, configFilename;
+  let fileData, configFilename, fileConfig;
 
   if (config_file) {
     configFilename = config_file;
@@ -123,14 +123,13 @@ const read_from_config_file = (project_path, config_file) => {
     return config;
   }
 
-  let fileConfig
   try {
     fileConfig = toml.parse(fileData);
-  } catch(e) {
+  } catch (e) {
     if (e.name === 'SyntaxError') {
-      throw niceTomlSyntaxError(e, configFilename, fileData)
+      throw niceTomlSyntaxError(e, configFilename, fileData);
     } else {
-      throw e
+      throw e;
     }
   }
   for (const field in fileConfig) {
@@ -348,26 +347,18 @@ function sourceLine(lineNum, source) {
     `${chalk.white(source)}`;
 }
 
-function leftPad(length) {
-  let leftPadding = '';
-  for (let i = 0; i < length; i++) {
-    leftPadding += ' ';
-  }
-  return leftPadding;
-}
-
 function niceTomlSyntaxError(e, configFilename, fileData) {
   const context = fileData
           .toString()
           .split('\n')
-          .slice(e.line-2, e.line+1);
+          .slice(e.line - 2, e.line + 1);
   return new Error(`\
 There was a syntax error when parsing ${configFilename}
 Check out line ${e.line}, column ${e.column}:
 
 ${sourceLine(e.line - 1, context[0])}
 ${sourceLine(e.line, context[1])}
-${leftPad(`${e.line}: `.length)}${leftPad(e.column-1)}${chalk.green.bold('^')}
+${' '.repeat(`${e.line}: `.length + e.column - 1)}${chalk.green.bold('^')}
 ${sourceLine(e.line + 1, context[2])}
 
 Common problems are:

--- a/cli/src/utils/proc-promise.js
+++ b/cli/src/utils/proc-promise.js
@@ -1,3 +1,4 @@
+'use strict';
 const Promise = require('bluebird');
 const childProcess = require('child_process');
 
@@ -12,12 +13,12 @@ function procPromise() {
       if (code === 0) {
         resolve(proc);
       } else {
-        reject(new Error(proc.stderr.read()));
+        const err = new Error(proc.stderr.read());
+        err.exitCode = code;
+        reject(err);
       }
-    })
+    });
   });
 }
 
-module.exports = {
-  procPromise
-}
+module.exports = procPromise;

--- a/cli/src/utils/proc-promise.js
+++ b/cli/src/utils/proc-promise.js
@@ -1,0 +1,23 @@
+const Promise = require('bluebird');
+const childProcess = require('child_process');
+
+function procPromise() {
+  // Takes the same arguments as child_process.spawn
+  const args = Array.prototype.slice.call(arguments);
+  return new Promise((resolve, reject) => {
+    const proc = childProcess.spawn.apply(childProcess, args);
+    proc.stderr.setEncoding('utf8');
+    proc.stdout.setEncoding('utf8');
+    proc.on('exit', (code) => {
+      if (code === 0) {
+        resolve(proc);
+      } else {
+        reject(new Error(proc.stderr.read()));
+      }
+    })
+  });
+}
+
+module.exports = {
+  procPromise
+}


### PR DESCRIPTION
fixes #756 
- Parse errors in config.toml are much more informative now:

![selection_088](https://cloud.githubusercontent.com/assets/1366/17721153/f4fc5bb2-63dc-11e6-8b62-0cb041db772e.png)
- Added a new `--unportable-backup` flag for hz migrate to allow using `tar` if the python driver isn't installed
- Cleaned up some other errors in `hz migrate` and made them nicer
- Fixed the outer catch for the cli, it was not catching exceptions. (Also, it no longer prints stack traces, since those look really nasty and only help us, not the end user)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/757)

<!-- Reviewable:end -->
