### PR TITLE
feature: allow passing in rdb ssl cert to Server

### DIFF
--- a/server/src/reql_connection.js
+++ b/server/src/reql_connection.js
@@ -12,7 +12,7 @@ class ReqlConnection {
   constructor(host, port, db,
               auto_create_collection, auto_create_index,
               user, pass, connect_timeout,
-              interruptor) {
+              interruptor, ca) {
     this._rdb_options = {
       host,
       port,
@@ -21,6 +21,9 @@ class ReqlConnection {
       password: pass || default_pass,
       timeout: connect_timeout || null,
     };
+    if (ca != null) {
+      this._rdb_options.ssl = { ca };
+    }
 
     this._auto_create_collection = auto_create_collection;
     this._auto_create_index = auto_create_index;

--- a/server/src/schema/server_options.js
+++ b/server/src/schema/server_options.js
@@ -20,6 +20,7 @@ const server = Joi.object({
   rdb_user: Joi.string().allow(null),
   rdb_password: Joi.string().allow(null),
   rdb_timeout: Joi.number().allow(null),
+  rdb_ca: Joi.binary().allow(null),
 }).unknown(false);
 
 const auth = Joi.object({

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -88,7 +88,8 @@ class Server {
                                            opts.rdb_user || null,
                                            opts.rdb_password || null,
                                            opts.rdb_timeout || null,
-                                           this._interruptor);
+                                           this._interruptor,
+                                           opts.rdb_ca || null);
       this._auth = new Auth(this, opts.auth);
       for (const key in endpoints) {
         this.add_request_handler(key, endpoints[key].run);


### PR DESCRIPTION
Based on @b-d 's comment here: https://github.com/rethinkdb/horizon/issues/680#issuecomment-240522809

This just adds it to the server, not to `hz serve` options etc. We could add it if people want.

Also, I didn't test or write tests for this.

ping @Tryneus for review

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/758)

<!-- Reviewable:end -->
