### PR TITLE
Fix group deletion behavior in server

### DIFF
--- a/server/src/metadata/metadata.js
+++ b/server/src/metadata/metadata.js
@@ -122,10 +122,8 @@ class Metadata {
                   this._clients.forEach((c) => c.group_changed(group.name));
                 } else if (change.type === 'uninitial' ||
                            change.type === 'remove') {
-                  const group = this._groups.delete(change.old_val.id);
-                  if (group) {
-                    this._clients.forEach((c) => c.group_changed(group.name));
-                  }
+                  this._groups.delete(change.old_val.id);
+                  this._clients.forEach((c) => c.group_changed(change.old_val.id));
                 }
               }).catch(reject);
             });


### PR DESCRIPTION
While porting code to the permissions plugin, I noticed this logic was wrong, would be nice to have it fixed until plugins hit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/767)

<!-- Reviewable:end -->
