### PR TITLE
Fix, setAuthFromQueryParams() compatible with React Native (android)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -75,7 +75,7 @@
     "dist/horizon-core-dev.js.map",
     "lib/*"
   ],
-  "babel": {
+  "_babel": {
     "presets": [
       "es2015-loose",
       {

--- a/client/package.json
+++ b/client/package.json
@@ -75,7 +75,7 @@
     "dist/horizon-core-dev.js.map",
     "lib/*"
   ],
-  "_babel": {
+  "babel": {
     "presets": [
       "es2015-loose",
       {

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -102,7 +102,8 @@ export class TokenStorage {
   }
 
   setAuthFromQueryParams() {
-    const parsed = typeof window !== 'undefined' ?
+    const parsed = typeof window !== 'undefined' &&
+      typeof window.location !== 'undefined' ?
             queryParse(window.location.search) : {}
 
     if (parsed.horizon_token != null) {


### PR DESCRIPTION
`window` exists on Android but does not have a `location` property, so
it’s necessary to check that `window.location` is not null before trying to access `window.location.search`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/770)

<!-- Reviewable:end -->
