### PR TITLE
fix: allow order without .limit

### DIFF
--- a/client/src/ast.js
+++ b/client/src/ast.js
@@ -19,6 +19,8 @@ import checkArgs from './util/check-args'
 import validIndexValue from './util/valid-index-value.js'
 import { serialize } from './serialization.js'
 
+import watchRewrites from './hacks/watch-rewrites'
+
 
 /**
  @this TermBase
@@ -76,7 +78,8 @@ export class TermBase {
   // returned which will lazily emit the query when it is subscribed
   // to
   watch({ rawChanges = false } = {}) {
-    const raw = this._sendRequest('subscribe', this._query)
+    const query = watchRewrites(this, this._query)
+    const raw = this._sendRequest('subscribe', query)
     if (rawChanges) {
       return raw
     } else {

--- a/client/src/hacks/watch-rewrites.js
+++ b/client/src/hacks/watch-rewrites.js
@@ -1,0 +1,26 @@
+/*
+ Some common queries run on an entire collection or on a collection of
+ indeterminate size. RethinkDB doesn't actually keep track of the
+ ordering of these queries when sending changes. The initial changes
+ will be ordered, but subsequent changes come in arbitrary order and
+ don't respect the ordering of the query. So, for convenience, we add
+ a very high limit so that the server will keep track of the order for
+ us.
+
+ Note: queries like collection.order(field).watch are not reasonable
+ in production systems. You should add an explicit limit.
+*/
+
+export default function watchRewrites(self, query) {
+  // The only query type at the moment that doesn't get these rewrites
+  // is find, since it returns a single document
+  if (query.find === undefined &&
+      query.order !== undefined &&
+      query.limit === undefined) {
+    const limit = self.constructor.IMPLICIT_LIMIT || 100000
+    // Need to copy the object, since it could be reused
+    return Object.assign({ limit }, query)
+  } else {
+    return query
+  }
+}


### PR DESCRIPTION
This fixes #542 

Implicitly rewrite anything with an `order` field but not a `limit` field to have a `limit(100000)`

@Tryneus

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/786)

<!-- Reviewable:end -->
