### PR TITLE
Remove --config option from cli commands

### DIFF
--- a/cli/src/make-token.js
+++ b/cli/src/make-token.js
@@ -15,11 +15,6 @@ const parseArguments = (args) => {
   const parser = new argparse.ArgumentParser({ prog: 'hz make-token' });
 
   parser.addArgument(
-    [ '--config' ],
-    { type: 'string', metavar: 'PATH',
-      help: 'Path to the config file to use, defaults to ".hz/config.toml".' });
-
-  parser.addArgument(
     [ '--token-secret' ],
     { type: 'string', metavar: 'SECRET',
       help: 'Secret key for signing the token.' });
@@ -38,9 +33,9 @@ const processConfig = (parsed) => {
   options = config.default_options();
 
   options = config.merge_options(
-    options, config.read_from_config_file(parsed.project_path, parsed.config));
+    options, config.read_from_config_file(parsed.project_path));
   options = config.merge_options(
-    options, config.read_from_secrets_file(parsed.project_path, parsed.config));
+    options, config.read_from_secrets_file(parsed.project_path));
   options = config.merge_options(options, config.read_from_env());
   options = config.merge_options(options, config.read_from_flags(parsed));
 

--- a/cli/src/migrate.js
+++ b/cli/src/migrate.js
@@ -82,11 +82,6 @@ function processConfig(cmdArgs) {
     help: 'Start up a RethinkDB server in the current directory',
   });
 
-  parser.addArgument([ '--config' ], {
-    default: '.hz/config.toml',
-    help: 'Path to the config file to use, defaults to ".hz/config.toml".',
-  });
-
   parser.addArgument([ '--skip-backup' ], {
     metavar: 'yes|no',
     default: 'no',
@@ -107,7 +102,7 @@ function processConfig(cmdArgs) {
   });
 
   const parsed = parser.parseArgs(cmdArgs);
-  const confOptions = config.read_from_config_file(parsed.project_path, parsed.config);
+  const confOptions = config.read_from_config_file(parsed.project_path);
   const envOptions = config.read_from_env();
   config.merge_options(confOptions, envOptions);
   // Pull out the relevant settings from the config file

--- a/cli/src/schema.js
+++ b/cli/src/schema.js
@@ -65,10 +65,6 @@ const parseArguments = (args) => {
       { type: 'string', metavar: 'yes|no', constant: 'yes', nargs: '?',
         help: 'Start up a RethinkDB server in the current directory' });
 
-    subcmd.addArgument([ '--config' ],
-      { type: 'string', metavar: 'PATH',
-        help: 'Path to the config file to use, defaults to ".hz/config.toml".' });
-
     subcmd.addArgument([ '--debug' ],
       { type: 'string', metavar: 'yes|no', constant: 'yes', nargs: '?',
         help: 'Enable debug logging.' });
@@ -189,7 +185,7 @@ const processApplyConfig = (parsed) => {
 
   options = config.default_options();
   options = config.merge_options(options,
-    config.read_from_config_file(parsed.project_path, parsed.config));
+    config.read_from_config_file(parsed.project_path));
   options = config.merge_options(options, config.read_from_env());
   options = config.merge_options(options, config.read_from_flags(parsed));
 
@@ -224,7 +220,7 @@ const processSaveConfig = (parsed) => {
   options.start_rethinkdb = true;
 
   options = config.merge_options(options,
-    config.read_from_config_file(parsed.project_path, parsed.config));
+    config.read_from_config_file(parsed.project_path));
   options = config.merge_options(options, config.read_from_env());
   options = config.merge_options(options, config.read_from_flags(parsed));
 

--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -123,10 +123,6 @@ const parseArguments = (args) => {
       '--allow-anonymous=yes ' +
       'and --serve-static=./dist.' });
 
-  parser.addArgument([ '--config' ],
-    { type: 'string', metavar: 'PATH',
-      help: 'Path to the config file to use, defaults to "${config.default_config_file}".' });
-
   parser.addArgument([ '--schema-file' ],
     { type: 'string', metavar: 'SCHEMA_FILE_PATH',
       help: 'Path to the schema file to use, ' +
@@ -267,10 +263,10 @@ const processConfig = (parsed) => {
   options = config.default_options();
 
   options = config.merge_options(options,
-    config.read_from_config_file(parsed.project_path, parsed.config));
+    config.read_from_config_file(parsed.project_path));
 
   options = config.merge_options(options,
-    config.read_from_secrets_file(parsed.project_path, parsed.config));
+    config.read_from_secrets_file(parsed.project_path));
 
   options = config.merge_options(options, config.read_from_env());
 

--- a/cli/src/utils/config.js
+++ b/cli/src/utils/config.js
@@ -104,14 +104,12 @@ const parse_connect = (connect, config) => {
   }
 };
 
-const read_from_config_file = (project_path, config_file) => {
+const read_from_config_file = (project_path) => {
   const config = { auth: { } };
 
   let fileData, configFilename, fileConfig;
 
-  if (config_file) {
-    configFilename = config_file;
-  } else if (project_path && !config_file) {
+  if (project_path) {
     configFilename = `${project_path}/${default_config_file}`;
   } else {
     configFilename = default_config_file;
@@ -146,14 +144,12 @@ const read_from_config_file = (project_path, config_file) => {
   return config;
 };
 
-const read_from_secrets_file = (projectPath, secretsFile) => {
+const read_from_secrets_file = (projectPath) => {
   const config = { auth: { } };
 
   let fileData, secretsFilename;
 
-  if (secretsFile) {
-    secretsFilename = secretsFile;
-  } else if (projectPath && !secretsFile) {
+  if (projectPath) {
     secretsFilename = `${projectPath}/${default_secrets_file}`;
   } else {
     secretsFilename = default_secrets_file;


### PR DESCRIPTION
This was a little outdated (we had a way to specify `config.toml`, but not `secrets.toml`, and the help text was a little broken), and didn't work according to #781.  Rather than complicate things by adding even more options, `config.toml` and `secrets.toml` are now always expected to be in `${project_dir}/.hz/`.  This should simplify things a bit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/788)

<!-- Reviewable:end -->
