### PR TITLE
Add option to force https for auth

### DIFF
--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -336,6 +336,7 @@ const start_horizon_server = (http_servers, opts) =>
     project_name: opts.project_name,
     access_control_allow_origin: opts.access_control_allow_origin,
     auth: {
+      secure: opts.secure,
       token_secret: opts.token_secret,
       allow_unauthenticated: opts.allow_unauthenticated,
       allow_anonymous: opts.allow_anonymous,
@@ -372,8 +373,8 @@ const run = (args, interruptor) => {
     logger.level = opts.debug ? 'debug' : 'warn';
 
     if (!opts.secure && opts.auth && Array.from(Object.keys(opts.auth)).length > 0) {
-      logger.warn('Authentication requires that the server be accessible via HTTPS. ' +
-                  'Either specify "secure=true" or use a reverse proxy.');
+      logger.warn('Authentication should only be used with a server accessible via ' +
+                  'HTTPS. Either specify "secure=true" or use a reverse proxy.');
     }
 
     change_to_project_dir(opts.project_path);

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -56,6 +56,7 @@ class Auth {
     this._new_user_group = options.new_user_group;
     this._allow_anonymous = options.allow_anonymous;
     this._allow_unauthenticated = options.allow_unauthenticated;
+    this._secure = options.secure;
 
     this._parent = server;
   }

--- a/server/src/auth/auth0.js
+++ b/server/src/auth/auth0.js
@@ -22,9 +22,6 @@ function auth0(horizon, raw_options) {
   const client_secret = options.secret;
   const host = options.host;
 
-  const self_url = (self_host, path) =>
-    url.format({ protocol: 'https', host: self_host, pathname: path });
-
   const make_acquire_url = (state, redirect_uri) =>
     url.format({ protocol: 'https',
                  host: host,

--- a/server/src/schema/server_options.js
+++ b/server/src/schema/server_options.js
@@ -23,6 +23,7 @@ const server = Joi.object({
 }).unknown(false);
 
 const auth = Joi.object({
+  secure: Joi.boolean().default(true),
   success_redirect: Joi.string().default('/'),
   failure_redirect: Joi.string().default('/'),
 


### PR DESCRIPTION
Addresses issue #508.  In the CLI, we will set `auth.secure` to the value of `--secure`.  If enabled (the default), we will only redirect back to HTTPS at the end of the oauth flow.  If disabled, we will inspect the request to see if it is on a secure connection (`req.connection.encrypted`).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/794)

<!-- Reviewable:end -->
