### PR TITLE
Add support for jsnext:main

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -53,7 +53,7 @@
     "webpack": "^1.12.14"
   },
   "main": "lib/index.js",
-  "jsmain:next": "src/index.js",
+  "jsnext:main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/rethinkdb/horizon.git"
@@ -73,7 +73,8 @@
     "dist/horizon-core.js.map",
     "dist/horizon-core-dev.js",
     "dist/horizon-core-dev.js.map",
-    "lib/*"
+    "lib/*",
+    "src/*"
   ],
   "babel": {
     "presets": [


### PR DESCRIPTION
- fix typo (`jsnext:main`, not `jsmain:next`)
- include `src/` in distributed version so that `jsnext:main` references a real artifact

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/820)

<!-- Reviewable:end -->
