### PR TITLE
Add Typescript Definitions

### DIFF
--- a/client/index.d.ts
+++ b/client/index.d.ts
@@ -1,0 +1,74 @@
+
+import { Observable } from 'rxjs';
+
+declare namespace hz {
+    type Bound = 'open' | 'closed';
+    type Direction = 'ascending' | 'descending';
+    type Primitive = boolean | number | string | Date;
+    type IdValue = Primitive | Primitive[] | { id: Primitive };
+
+    interface TermBase {
+        watch (options?: { rawChanges: boolean }): TermBase;
+        fetch (): TermBase;
+
+        findAll (...values: IdValue[]): TermBase;
+        find (value: IdValue): TermBase;
+
+        order (fields: string[], direction?: Direction): TermBase;
+        limit (size: Number): TermBase;
+        above (spec: any, bound?: Bound): TermBase;
+        below (spec: any, bound?: Bound): TermBase;
+    }
+
+    type WriteOp = Object | Object[];
+
+    interface Collection extends TermBase {
+        store (docs: WriteOp): Observable<any>;
+        upsert (docs: WriteOp): Observable<any>;
+        insert (docs: WriteOp): Observable<any>;
+        replace (docs: WriteOp): Observable<any>;
+        update (docs: WriteOp): Observable<any>;
+        remove (docs: IdValue): Observable<any>;
+        remove (docs: IdValue[]): Observable<any>;
+    }
+
+    interface User extends TermBase {}
+
+    interface HorizonInstance {
+        (name: string): Collection;
+
+        currentUser (): User;
+
+        aggregate (aggs: any): TermBase;
+        model (fn: Function): TermBase;
+
+        disconnect (): void;
+        connect (): void;
+
+        status (): Observable<any>;
+        onReady (): Observable<any>;
+        onDisconnected (): Observable<any>;
+        onSocketError (): Observable<any>;
+    }
+
+    interface HorizonOptions {
+        host?: string;
+        path?: string;
+        secure?: boolean;
+
+        authType?: string;
+        lazyWrites?: boolean;
+        keepalive?: number;
+
+        WebSocketCtor?: any;
+    }
+
+    interface Horizon {
+        (options: HorizonOptions): HorizonInstance;
+
+        clearAuthTokens (): void;
+    }
+}
+
+declare var Horizon: hz.Horizon;
+export default Horizon;


### PR DESCRIPTION
In order for Typescript projects to recognize `import`s from npm packages, a `.d.ts` typings definitions file must be present or referenced externally. Adding a `typings` definition allows Horizon to be seamlessly imported into Angular 2 applications.

```
npm install @horizon/client --save
```

``` js
import Horizon from '@horizon/client';
```

Without this, you are forced to either reference Horizon as a global via a `<script>` tag or specify additional `scripts` via `angular-cli.json` and use `require`.

I attempted to cover all of the public API in these definitions, but I'm sure it's not totally complete yet. I think this provides a good enough starting point to at least get things working in Angular 2.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/821)

<!-- Reviewable:end -->
