### PR TITLE
Fix: move .babelrc to its own file.

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    "es2015",
+    {
+      "plugins": [
+        [
+          "transform-runtime",
+          {
+            "polyfill": false
+          }
+        ]
+      ]
+    }
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,6 @@
     "babel-plugin-istanbul": "^1.0.3",
     "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2015-loose": "^7.0.0",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
     "copy-webpack-plugin": "^3.0.1",
@@ -75,28 +74,6 @@
     "dist/horizon-core-dev.js.map",
     "lib/*"
   ],
-  "babel": {
-    "presets": [
-      "es2015-loose",
-      {
-        "plugins": [
-          [
-            "transform-runtime",
-            {
-              "polyfill": false
-            }
-          ]
-        ]
-      }
-    ],
-    "env": {
-      "test": {
-        "plugins": [
-          "istanbul"
-        ]
-      }
-    }
-  },
   "nyc": {
     "all": true,
     "statements": 82.02,

--- a/client/webpack.horizon.config.js
+++ b/client/webpack.horizon.config.js
@@ -73,7 +73,7 @@ module.exports = function(buildTarget) {
           loader: 'babel-loader',
           query: {
             cacheDirectory: true,
-            extends: path.resolve(__dirname, 'package.json'),
+            extends: path.resolve(__dirname, '.babelrc'),
           },
         },
       ],


### PR DESCRIPTION
This breaks nothing, our .babelrc shouldn't go out with the distributed package.

One caveat is that if you're doing React Native development, and you have horizon checked out from git and `npm link`ed into your node modules, you'll get the same error as before. (Because the babelrc will be back since it's not the distributed version, just the version from

Fixes #814 
Fixes #798 
Fixes #255 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/823)

<!-- Reviewable:end -->
