### PR TITLE
Include request_id in handshake error responses

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -66,16 +66,16 @@ class Auth {
       return this._jwt.verify(request.token);
     case 'unauthenticated':
       if (!this._allow_unauthenticated) {
-        throw new Error('Unauthenticated connections are not allowed.');
+        return Promise.reject(new Error('Unauthenticated connections are not allowed.'));
       }
       return this._jwt.verify(this._jwt.sign({ id: null, provider: request.method }).token);
     case 'anonymous':
       if (!this._allow_anonymous) {
-        throw new Error('Anonymous connections are not allowed.');
+        return Promise.reject(new Error('Anonymous connections are not allowed.'));
       }
       return this.generate(request.method, r.uuid());
     default:
-      throw new Error(`Unknown handshake method "${request.method}"`);
+      return Promise.reject(new Error(`Unknown handshake method "${request.method}"`));
     }
   }
 


### PR DESCRIPTION
Fixes #838 

When an exception is thrown inside `handshake` (server/src/auth.js) it is currently caught in `error_wrap_socket` (server/src/client.js) where the originating request's `request_id` is unknown. Failed handshake requests will therefore respond with `request_id: null`

This change is to instead return a rejected promise, which will be caught in the catch clause inside `handle_handshake` (server/src/client.js), from where a JSON response is sent including the `request_id`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/839)

<!-- Reviewable:end -->
