### PR TITLE
Add more complex filtering using Validators

### DIFF
--- a/cli/src/init.js
+++ b/cli/src/init.js
@@ -62,6 +62,15 @@ project_name = "${projectName}"
 
 
 ###############################################################################
+# Filter Options
+# WARNING: This option might have performance implications
+# 'enable_subscribe_validator_filter' will filter results failing validation from
+# the result set, instead of throwing an exception
+#------------------------------------------------------------------------------
+# enable_subscribe_validator_filter = false
+
+
+###############################################################################
 # Data Options
 # WARNING: these should probably not be enabled on a publically accessible
 # service.  Tables and indexes are not lightweight objects, and allowing them

--- a/cli/src/serve.js
+++ b/cli/src/serve.js
@@ -334,6 +334,7 @@ const processConfig = (parsed) => {
 
 const start_horizon_server = (http_servers, opts) =>
   new horizon_server.Server(http_servers, {
+    enable_subscribe_validator_filter: opts.enable_subscribe_validator_filter,
     auto_create_collection: opts.auto_create_collection,
     auto_create_index: opts.auto_create_index,
     permissions: opts.permissions,

--- a/cli/src/utils/config.js
+++ b/cli/src/utils/config.js
@@ -34,6 +34,9 @@ const make_default_options = () => ({
   cert_file: './horizon-cert.pem',
   schema_file: null,
 
+  // Enable subscribe validator filtering instead of exception throwing
+  enable_subscribe_validator_filter: false,
+
   auto_create_collection: false,
   auto_create_index: false,
 
@@ -59,6 +62,7 @@ const yes_no_options = [ 'debug',
                          'secure',
                          'permissions',
                          'start_rethinkdb',
+                         'enable_subscribe_validator_filter',
                          'auto_create_index',
                          'auto_create_collection',
                          'allow_unauthenticated',

--- a/server/src/endpoint/subscribe.js
+++ b/server/src/endpoint/subscribe.js
@@ -22,7 +22,11 @@ const run = (raw_request, context, ruleset, metadata, send, done) => {
           send({ state: 'synced' });
         } else if ((item.old_val && !ruleset.validate(context, item.old_val)) ||
                    (item.new_val && !ruleset.validate(context, item.new_val))) {
-          throw new Error('Operation not permitted.');
+          if (metadata._subscribe_validator_filter_enabled) {
+            console.log('Filtering record from result set')
+          } else {
+            throw new Error('Operation not permitted.');
+          }
         } else {
           send({ data: [ item ] });
         }

--- a/server/src/metadata/metadata.js
+++ b/server/src/metadata/metadata.js
@@ -46,11 +46,13 @@ class Metadata {
   constructor(project_name,
               conn,
               clients,
+              enable_subscribe_validator_filter,
               auto_create_collection,
               auto_create_index) {
     this._db = project_name;
     this._conn = conn;
     this._clients = clients;
+    this._subscribe_validator_filter_enabled = enable_subscribe_validator_filter;
     this._auto_create_collection = auto_create_collection;
     this._auto_create_index = auto_create_index;
     this._closed = false;

--- a/server/src/reql_connection.js
+++ b/server/src/reql_connection.js
@@ -10,6 +10,7 @@ const default_pass = '';
 
 class ReqlConnection {
   constructor(host, port, db,
+              enable_subscribe_validator_filter,
               auto_create_collection, auto_create_index,
               user, pass, connect_timeout,
               interruptor) {
@@ -22,6 +23,7 @@ class ReqlConnection {
       timeout: connect_timeout || null,
     };
 
+    this._subscribe_validator_filter_enabled = enable_subscribe_validator_filter;
     this._auto_create_collection = auto_create_collection;
     this._auto_create_index = auto_create_index;
     this._clients = new Set();
@@ -83,6 +85,7 @@ class ReqlConnection {
       return new Metadata(this._rdb_options.db,
                           conn,
                           this._clients,
+                          this._subscribe_validator_filter_enabled,
                           this._auto_create_collection,
                           this._auto_create_index).ready();
     }).then((metadata) => {

--- a/server/src/schema/server_options.js
+++ b/server/src/schema/server_options.js
@@ -7,6 +7,8 @@ const server = Joi.object({
   rdb_host: Joi.string().hostname().default('localhost'),
   rdb_port: Joi.number().greater(0).less(65536).default(28015),
 
+  enable_subscribe_validator_filter: Joi.boolean().default(false),
+
   auto_create_collection: Joi.boolean().default(false),
   auto_create_index: Joi.boolean().default(false),
 

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -71,6 +71,7 @@ class Server {
     this._name = opts.project_name;
     this._max_connections = opts.max_connections;
     this._permissions_enabled = opts.permissions;
+    this._subscribe_validator_filter_enabled = opts.enable_subscribe_validator_filter;
     this._auth_methods = { };
     this._request_handlers = new Map();
     this._http_handlers = new Map();
@@ -84,6 +85,7 @@ class Server {
       this._reql_conn = new ReqlConnection(opts.rdb_host,
                                            opts.rdb_port,
                                            opts.project_name,
+                                           opts.enable_subscribe_validator_filter,
                                            opts.auto_create_collection,
                                            opts.auto_create_index,
                                            opts.rdb_user || null,


### PR DESCRIPTION
See Issue https://github.com/rethinkdb/horizon/issues/866 for description.

This pull adds a enable_subscribe_validator_filter option, which will filter documents from a subscribe call which do not pass the validator. The filtering happens INSTEAD of the entire query being blocked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/867)
<!-- Reviewable:end -->
