### PR TITLE
Update express-server example to latest version

### DIFF
--- a/examples/express-server/README.md
+++ b/examples/express-server/README.md
@@ -1,0 +1,44 @@
+
+#Embedding horizon within express
+
+This folder contains a simple example that shows how to embed horizon within an express server. This offers the opportunity to integrate horizon at different stages with an express app. 
+
+###Before we start
+Make sure that you have the latest version of horizon installed. [Installing horizon](http://horizon.io/install/).
+At the same time make sure that you have rethinkdb installed. [Installing rethinkdb](https://www.rethinkdb.com/docs/install/).
+
+###Running the example
+Let's initialize our app using horizon cli, we will call this app **example_app**.
+
+```
+hz init example_app
+```
+Let's turn on rethinkdb which will by default listen at port 28015.
+```
+rethinkdb
+```
+the **hz init** command will create a directory for us called example_app (which is the app name), now we will go to that directory.
+
+```
+cd example_app
+```
+Our default schema is found in **.hz** directory, to apply that schema we run the following command.
+```
+hz schema apply .hz/schema.toml
+```
+Copy the files of this repo (main.js and package.json) to our example_app directory, then run the following commands
+
+```
+npm i
+node main.js
+```
+That's it. Head to http://localhost:8181 to see the example app running.
+
+
+
+
+
+
+
+
+   

--- a/examples/express-server/main.js
+++ b/examples/express-server/main.js
@@ -5,8 +5,19 @@ const express = require('express');
 const horizon = require('@horizon/server');
 
 const app = express();
+
+app.use(express.static('./dist'));
+
 const http_server = app.listen(8181);
-const options = { auth: { token_secret: 'my_super_secret_secret' } };
+const options = {
+  project_name: 'example_app',
+  auth: {
+    token_secret: 'my_super_secret_secret',
+    // make sure that the following is set to true, otherwise
+    // horizon client wont be able to connect using default constructor
+    allow_unauthenticated: true,
+  },
+};
 const horizon_server = horizon(http_server, options);
 
 console.log('Listening on port 8181.');

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -9,8 +9,8 @@
   "author": "RethinkDB",
   "license": "MIT",
   "dependencies": {
-    "@horizon/server": "^1.0.1",
-    "express": "^4.13.3"
+    "@horizon/server": "^2.0.0",
+    "express": "^4.14.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In an attempt to embed horizon in an express app, I realized that the example in this repo is for horizon 1.0.1 and doesn't work out of the box with current horizon version.

I updated the necessary files, and created a README.md that shows a tutorial to facilitate the process for new comers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/868)
<!-- Reviewable:end -->
