### PR TITLE
Scrub some horizon.io links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [Official Repository](https://github.com/rethinkdb/horizon)
 
-[![CircleCI](https://circleci.com/gh/rethinkdb/horizon/tree/next.svg?style=svg)](https://circleci.com/gh/rethinkdb/horizon/tree/next)
-
 ## What is Horizon?
 
 Horizon is an open-source developer platform for building sophisticated realtime

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <img style="width:100%;" src="/github-banner.png">
 
-# [Horizon](https://horizon.io)
+# Horizon
+
+[Official Repository](https://github.com/rethinkdb/horizon)
+
 [![CircleCI](https://circleci.com/gh/rethinkdb/horizon/tree/next.svg?style=svg)](https://circleci.com/gh/rethinkdb/horizon/tree/next)
 
 ## What is Horizon?
@@ -73,8 +76,7 @@ We'd love for you to help us build Horizon. If you'd like to be a contributor,
 check out our [Contributing guide](/CONTRIBUTING.md).
 
 Also, to stay up-to-date on all Horizon related news and the community you should
-definitely [join us on Slack](http://slack.rethinkdb.com), [follow us on Twitter](https://twitter.com/horizonjs),
-and join our Horizon mailing list at [Horizon.io](https://horizon.io).
+definitely [join us on Slack](http://slack.rethinkdb.com) or [follow us on Twitter](https://twitter.com/horizonjs).
 
 ![](/assets/Lets-go.png)
 

--- a/examples/angularjs-todo-app/README.md
+++ b/examples/angularjs-todo-app/README.md
@@ -1,11 +1,11 @@
 #TodoMVC
 
-A basic example of using [AngularJS](http://angularjs.org/) and [Horizon](http://horizon.io/) to create real-time TodoMVC app.
+A basic example of using [AngularJS](http://angularjs.org/) and Horizon to create real-time TodoMVC app.
 
 ## Prerequisites
 
 - [RethinkDB](https://www.rethinkdb.com/docs/install/) (The open-source database for the realtime web)
-- [Horizon](http://horizon.io/install/) (A realtime, open-source backend for JavaScript apps)
+- [Horizon](https://github.com/rethinkdb/horizon/) (A realtime, open-source backend for JavaScript apps)
 
 ## Installing
 


### PR DESCRIPTION
Removes some links to the horizon.io page.

Some others remain; they point to specific documentation, and that'll be in a separate PR.

Addresses #898 (partly).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/900)
<!-- Reviewable:end -->
