### PR TITLE
Change Horizon documentation URLs

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -33,20 +33,20 @@ npm run test        | Run tests
 
 ### Getting Started
 
-[horizon.io/docs/getting-started](https://horizon.io/docs/getting-started/).
+[samuelhughes.com/rethinkdb/horizon-docs/docs/getting-started.html](http://samuelhughes.com/rethinkdb/horizon-docs/docs/getting-started.html)
 
 ### APIs
 
-* Horizon API - [horizon.io/api/horizon/](https://horizon.io/api/horizon/)
-* Collection API - [horizon.io/api/collection/](https://horizon.io/api/collection/)
+* Horizon API - [samuelhughes.com/rethinkdb/horizon-docs/api/horizon.html](http://samuelhughes.com/rethinkdb/horizon-docs/api/horizon.html)
+* Collection API - [samuelhughes.com/rethinkdb/horizon-docs/api/horizon.html](http://samuelhughes.com/rethinkdb/horizon-docs/api/horizon.html)
 
 ## Users and Groups
 
-[horizon.io/docs/users/](https://horizon.io/docs/users/)
+[samuelhughes.com/rethinkdb/horizon-docs/docs/users.html](http://samuelhughes.com/rethinkdb/horizon-docs/docs/users.html)
 
 ## Setting Permissions
 
-[horizon.io/docs/permissions/](http://horizon.io/docs/permissions/)
+[samuelhughes.com/rethinkdb/horizon-docs/docs/permissions.html](http://samuelhughes.com/rethinkdb/horizon-docs/docs/permissions.html)
 
 ### Clearing tokens
 

--- a/server/README.md
+++ b/server/README.md
@@ -4,7 +4,7 @@ An extensible middleware server built on top of [RethinkDB](https://github.com/r
 
 ## Documentation
 
-Follow our documentation at [horizon.io/install](https://horizon.io/install) for instructions on installing Horizon.
+Follow our documentation at [samuelhughes.com/rethinkdb/horizon-docs/install.html](http://samuelhughes.com/rethinkdb/horizon-docs/install.html) for instructions on installing Horizon.
 
 ## Requirements
 The Horizon server requires some tools and libraries to be available before it


### PR DESCRIPTION
This changes the Horizon documentation URLs in the repository to point to samuelhughes.com's Horizon documentation page.  (That's my website.)

Perhaps this is slightly controversial, so I made it into a separate branch relative to PR #900.

I think it'd be preferable to point to some other website hosting the content.  Maybe a Github Pages type deal.

We could always change the URLs later, if that happens.

This PR relates to #898.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rethinkdb/horizon/901)
<!-- Reviewable:end -->
